### PR TITLE
fix: prevent invisible toasts from stale animation state and leaked timers

### DIFF
--- a/Display/ToastAnimations.lua
+++ b/Display/ToastAnimations.lua
@@ -110,6 +110,9 @@ end
 -------------------------------------------------------------------------------
 
 function ns.ToastAnimations.PlayEntrance(frame)
+    -- Defensive: clear any stale animation state from previous frame use
+    ns.ToastAnimations.StopAll(frame)
+
     local db = ns.Addon.db.profile
 
     if not db.animation.enableAnimations then
@@ -277,8 +280,10 @@ function ns.ToastAnimations.StopAll(frame)
     end
 
     for _, group in pairs(frame.animGroups) do
-        if group:IsPlaying() then
-            group:Stop()
-        end
+        group:Stop()
     end
+
+    -- Guarantee clean visual state after stopping all groups
+    frame:SetAlpha(1)
+    frame:SetScale(1)
 end

--- a/Display/ToastFrame.lua
+++ b/Display/ToastFrame.lua
@@ -449,11 +449,18 @@ function ns.ToastFrame.Acquire()
 end
 
 function ns.ToastFrame.Release(frame)
+    -- Cancel any pending fade timer before releasing
+    if frame.fadeTimer then
+        ns.Addon:CancelTimer(frame.fadeTimer)
+    end
+
     frame:Hide()
     frame:ClearAllPoints()
     frame.lootData = nil
     frame.isHovered = false
     frame.fadeTimer = nil
+    frame.fadeTimerStart = nil
+    frame.fadeTimerRemaining = nil
     frame._isEntering = false
     frame._entranceStartTime = nil
     frame._entranceDuration = nil
@@ -464,6 +471,11 @@ function ns.ToastFrame.Release(frame)
     frame:SetScript("OnUpdate", nil)
     frame:SetAlpha(1)
     frame:SetScale(1)
+
+    -- Pool duplication guard
+    for _, pooled in ipairs(framePool) do
+        if pooled == frame then return end
+    end
     table.insert(framePool, frame)
 end
 

--- a/Display/ToastManager.lua
+++ b/Display/ToastManager.lua
@@ -353,6 +353,12 @@ function ns.ToastManager.OnToastFinished(toast)
         end
     end
 
+    -- Safety: cancel any pending fade timer before releasing
+    if toast.fadeTimer then
+        ns.Addon:CancelTimer(toast.fadeTimer)
+        toast.fadeTimer = nil
+    end
+
     -- Release frame back to pool
     ns.ToastAnimations.StopAll(toast)
     ns.ToastFrame.Release(toast)


### PR DESCRIPTION
## Summary

Fixes a bug where toasts could become permanently invisible after being recycled from the frame pool. This manifested as "ghost" toasts that occupied queue slots but were never visible to the user.

## Root Cause

When a toast's exit animation group finished, `SetToFinalAlpha` left the frame at alpha 0. If the frame was returned to the pool without fully resetting this state, the next `Acquire` would hand out an invisible frame. Additionally, leaked `AceTimer` fade timers could fire on already-released frames, corrupting their state.

## Fixes

- **Defensive `StopAll` in `PlayEntrance`** — Clears any stale animation state (alpha/scale) left over from a previous lifecycle before starting entrance animations (`ToastAnimations.lua`)
- **Unconditional `group:Stop()` + alpha/scale reset in `StopAll`** — Removes the `IsPlaying()` guard so groups stuck in a finished-but-not-reset state are properly stopped, and guarantees `SetAlpha(1)` / `SetScale(1)` afterward (`ToastAnimations.lua`)
- **Cancel `AceTimer` in `Release` and `OnToastFinished`** — Prevents leaked fade timers from firing on recycled frames (`ToastFrame.lua`, `ToastManager.lua`)
- **Pool duplication guard in `Release`** — Checks whether the frame is already in `framePool` before reinserting, preventing double-pooling from redundant release paths (`ToastFrame.lua`)
- **Clear `fadeTimerStart` / `fadeTimerRemaining`** — Ensures stale pause/resume metadata doesn't carry over to the next toast lifecycle (`ToastFrame.lua`)