### PR TITLE
fix: correct branch name in CI workflows from main to master

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   luacheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
     inputs:
       tag_name:


### PR DESCRIPTION
Both lint.yml and release.yml were targeting 'main' but the default branch is 'master'. This meant Luacheck never ran on PRs and release-please never triggered on push to master.