### PR TITLE
refactor: remove pop animation system

### DIFF
--- a/Core/Config.lua
+++ b/Core/Config.lua
@@ -52,7 +52,7 @@ local defaults = {
             entranceDuration = 0.3,
             exitDuration = 0.5,
             holdDuration = 4.0,
-            enablePopEffect = true,
+
             entranceDirection = "RIGHT",
             entranceDistance = 300,
             slideSpeed = 0.2,
@@ -406,14 +406,6 @@ local function GetOptions()
                         min = 0.1, max = 2.0, step = 0.1,
                         get = function() return db.animation.exitDuration end,
                         set = function(_, val) db.animation.exitDuration = val end,
-                    },
-                    enablePopEffect = {
-                        name = "Pop Effect",
-                        desc = "Subtle scale bounce when a toast appears.",
-                        type = "toggle",
-                        order = 5,
-                        get = function() return db.animation.enablePopEffect end,
-                        set = function(_, val) db.animation.enablePopEffect = val end,
                     },
                     entranceDirection = {
                         name = "Entrance Direction",

--- a/Display/ToastAnimations.lua
+++ b/Display/ToastAnimations.lua
@@ -41,37 +41,6 @@ function ns.ToastAnimations.SetupAnimations(frame)
 
     frame.animGroups.entrance = entrance
 
-    -- Pop animation group (plays after entrance finishes)
-    local pop = frame.content:CreateAnimationGroup()
-
-    -- Pop: Scale up
-    local popUp = pop:CreateAnimation("Scale")
-    popUp:SetDuration(0.08)
-    popUp:SetScaleFrom(1.0, 1.0)
-    popUp:SetScaleTo(1.05, 1.05)
-    popUp:SetSmoothing("IN_OUT")
-    popUp:SetOrder(1)
-    popUp:SetOrigin("CENTER", 0, 0)
-
-    -- Pop: Scale back down
-    local popDown = pop:CreateAnimation("Scale")
-    popDown:SetDuration(0.07)
-    popDown:SetScaleFrom(1.05, 1.05)
-    popDown:SetScaleTo(1.0, 1.0)
-    popDown:SetSmoothing("IN_OUT")
-    popDown:SetOrder(2)
-    popDown:SetOrigin("CENTER", 0, 0)
-
-    frame.animGroups.pop = pop
-
-    -- Chain: entrance -> pop
-    entrance:SetScript("OnFinished", function()
-        local db = ns.Addon.db.profile
-        if db.animation.enableAnimations and db.animation.enablePopEffect then
-            pop:Play()
-        end
-    end)
-
     -- Exit animation group
     local exit = frame:CreateAnimationGroup()
     exit:SetToFinalAlpha(true)
@@ -229,12 +198,9 @@ function ns.ToastAnimations.PlayExit(frame)
         return
     end
 
-    -- Stop any running entrance/pop animations
+    -- Stop any running entrance animations
     if frame.animGroups.entrance:IsPlaying() then
         frame.animGroups.entrance:Stop()
-    end
-    if frame.animGroups.pop:IsPlaying() then
-        frame.animGroups.pop:Stop()
     end
 
     -- Set duration from config
@@ -286,5 +252,4 @@ function ns.ToastAnimations.StopAll(frame)
     -- Guarantee clean visual state after stopping all groups
     frame:SetAlpha(1)
     frame:SetScale(1)
-    if frame.content then frame.content:SetScale(1) end
 end

--- a/Display/ToastFrame.lua
+++ b/Display/ToastFrame.lua
@@ -71,27 +71,23 @@ local function CreateToastFrame()
     frame.borderRight:SetPoint("BOTTOMRIGHT")
     frame.borderRight:SetColorTexture(0.3, 0.3, 0.3, 0.8)
 
-    -- Content container (scales independently for pop animation)
-    frame.content = CreateFrame("Frame", nil, frame)
-    frame.content:SetAllPoints()
-
     -- Quality glow strip (left edge, 4px wide)
-    frame.qualityGlow = frame.content:CreateTexture(nil, "ARTWORK")
+    frame.qualityGlow = frame:CreateTexture(nil, "ARTWORK")
     frame.qualityGlow:SetWidth(4)
-    frame.qualityGlow:SetPoint("TOPLEFT", frame.content, "TOPLEFT", 1, -1)
-    frame.qualityGlow:SetPoint("BOTTOMLEFT", frame.content, "BOTTOMLEFT", 1, 1)
+    frame.qualityGlow:SetPoint("TOPLEFT", frame, "TOPLEFT", 1, -1)
+    frame.qualityGlow:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 1, 1)
     frame.qualityGlow:SetColorTexture(1, 1, 1, 0.8)
 
     -- Icon frame (container for icon + icon border)
     local iconSize = 36
     local iconPadding = 6
 
-    frame.icon = frame.content:CreateTexture(nil, "ARTWORK")
+    frame.icon = frame:CreateTexture(nil, "ARTWORK")
     frame.icon:SetSize(iconSize, iconSize)
-    frame.icon:SetPoint("LEFT", frame.content, "LEFT", iconPadding + 4, 0) -- +4 for glow strip
+    frame.icon:SetPoint("LEFT", frame, "LEFT", iconPadding + 4, 0) -- +4 for glow strip
     frame.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92) -- trim default icon borders
 
-    frame.iconBorder = frame.content:CreateTexture(nil, "OVERLAY")
+    frame.iconBorder = frame:CreateTexture(nil, "OVERLAY")
     frame.iconBorder:SetPoint("TOPLEFT", frame.icon, "TOPLEFT", -1, 1)
     frame.iconBorder:SetPoint("BOTTOMRIGHT", frame.icon, "BOTTOMRIGHT", 1, -1)
     frame.iconBorder:SetColorTexture(0.3, 0.3, 0.3, 0.8)
@@ -99,33 +95,33 @@ local function CreateToastFrame()
     frame.icon:SetDrawLayer("OVERLAY", 1)
 
     -- Item name (row 1, left)
-    frame.itemName = frame.content:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    frame.itemName = frame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
     frame.itemName:SetPoint("TOPLEFT", frame.icon, "TOPRIGHT", 8, -2)
-    frame.itemName:SetPoint("RIGHT", frame.content, "RIGHT", -80, 0)
+    frame.itemName:SetPoint("RIGHT", frame, "RIGHT", -80, 0)
     frame.itemName:SetJustifyH("LEFT")
     frame.itemName:SetWordWrap(false)
 
     -- Quantity badge (bottom-right of icon, stack count style)
-    frame.quantity = frame.content:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
+    frame.quantity = frame:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
     frame.quantity:SetPoint("BOTTOMRIGHT", frame.icon, "BOTTOMRIGHT", 2, -2)
     frame.quantity:SetJustifyH("RIGHT")
     frame.quantity:SetTextColor(1, 1, 1)
 
     -- Item level (row 1, right)
-    frame.itemLevel = frame.content:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    frame.itemLevel:SetPoint("TOPRIGHT", frame.content, "TOPRIGHT", -8, -6)
+    frame.itemLevel = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    frame.itemLevel:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -8, -6)
     frame.itemLevel:SetJustifyH("RIGHT")
     frame.itemLevel:SetTextColor(0.6, 0.6, 0.6)
 
     -- Type/Subtype (row 2, left)
-    frame.itemType = frame.content:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    frame.itemType = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     frame.itemType:SetPoint("BOTTOMLEFT", frame.icon, "BOTTOMRIGHT", 8, 2)
     frame.itemType:SetJustifyH("LEFT")
     frame.itemType:SetTextColor(0.5, 0.5, 0.5)
 
     -- Looter name (row 2, right)
-    frame.looter = frame.content:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    frame.looter:SetPoint("BOTTOMRIGHT", frame.content, "BOTTOMRIGHT", -8, 6)
+    frame.looter = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    frame.looter:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -8, 6)
     frame.looter:SetJustifyH("RIGHT")
     frame.looter:SetTextColor(0.7, 0.7, 0.7)
 
@@ -212,8 +208,8 @@ local function PopulateToast(frame, lootData)
         else
             frame.icon:Hide()
             frame.iconBorder:Hide()
-            frame.itemName:SetPoint("TOPLEFT", frame.content, "TOPLEFT", 10, -6)
-            frame.itemType:SetPoint("BOTTOMLEFT", frame.content, "BOTTOMLEFT", 10, 6)
+            frame.itemName:SetPoint("TOPLEFT", frame, "TOPLEFT", 10, -6)
+            frame.itemType:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 10, 6)
         end
 
         -- XP name in gold color
@@ -313,8 +309,8 @@ local function PopulateToast(frame, lootData)
         frame.icon:Hide()
         frame.iconBorder:Hide()
         -- Position text at left edge when no icon
-        frame.itemName:SetPoint("TOPLEFT", frame.content, "TOPLEFT", 10, -6)
-        frame.itemType:SetPoint("BOTTOMLEFT", frame.content, "BOTTOMLEFT", 10, 6)
+        frame.itemName:SetPoint("TOPLEFT", frame, "TOPLEFT", 10, -6)
+        frame.itemType:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 10, 6)
     end
 
     -- Quality color
@@ -475,8 +471,6 @@ function ns.ToastFrame.Release(frame)
     frame:SetScript("OnUpdate", nil)
     frame:SetAlpha(1)
     frame:SetScale(1)
-    if frame.content then frame.content:SetScale(1) end
-
     -- Pool duplication guard
     for _, pooled in ipairs(framePool) do
         if pooled == frame then return end


### PR DESCRIPTION
## Summary

- Removes the pop (scale bounce) animation group that played after entrance, including the entrance->pop chain
- Removes the `frame.content` sub-frame that was only needed for pop, reverting all content elements (textures, font strings, anchors) back to the main frame
- Removes the `enablePopEffect` config option and its default value