### PR TITLE
fix: lint workflow now triggers on release-please PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
 
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: nebularg/actions-luacheck@v1
         with:
           args: --no-color


### PR DESCRIPTION
## Summary

Changed `pull_request` to `pull_request_target` so the Luacheck status check runs on release-please bot PRs (GITHUB_TOKEN doesn't trigger `pull_request` events). Uses `head.sha` for safe checkout of PR code.