### PR TITLE
ci: fix BigWigsMods packager future tag error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,10 @@ jobs:
 
   package:
     needs: release-please
-    if: ${{ always() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ !failure() && !cancelled() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     env:
       CF_API_KEY: ${{ secrets.CF_API_KEY }}
-      WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
       WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
       GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -44,3 +43,5 @@ jobs:
 
       - name: Package and release
         uses: BigWigsMods/packager@v2
+        env:
+          GITHUB_REF: refs/tags/${{ needs.release-please.outputs.tag_name || github.event.inputs.tag_name }}


### PR DESCRIPTION
Fixes the 'Found future tag, not packaging' error from BigWigsMods/packager.

Changes:
- Override GITHUB_REF to refs/tags/<tag> so packager sees a tag context instead of branch push
- Replace always() with !failure() && !cancelled() for safer job conditions
- Remove unused WOWI_API_TOKEN

Ref: https://github.com/BigWigsMods/packager/issues/129