### PR TITLE
feat: add /dt reset command to restore default anchor position

### DIFF
--- a/Core/SlashCommands.lua
+++ b/Core/SlashCommands.lua
@@ -65,6 +65,7 @@ local function PrintHelp()
     print("  " .. ns.COLOR_WHITE .. "/dt lock" .. ns.COLOR_RESET .. " — Toggle anchor lock (drag to move)")
     print("  " .. ns.COLOR_WHITE .. "/dt test" .. ns.COLOR_RESET .. " — Show a test toast")
     print("  " .. ns.COLOR_WHITE .. "/dt clear" .. ns.COLOR_RESET .. " — Dismiss all toasts")
+    print("  " .. ns.COLOR_WHITE .. "/dt reset" .. ns.COLOR_RESET .. " — Reset anchor position to default")
     print("  " .. ns.COLOR_WHITE .. "/dt status" .. ns.COLOR_RESET .. " — Show current settings")
     print("  " .. ns.COLOR_WHITE .. "/dt help" .. ns.COLOR_RESET .. " — Show this help")
 end
@@ -105,6 +106,9 @@ function ns.HandleSlashCommand(input)
     elseif cmd == "clear" then
         ns.ToastManager.ClearAll()
         ns.Print("All toasts cleared.")
+
+    elseif cmd == "reset" then
+        ns.ToastManager.ResetAnchor()
 
     elseif cmd == "status" then
         PrintStatus()

--- a/Display/ToastManager.lua
+++ b/Display/ToastManager.lua
@@ -479,6 +479,15 @@ function ns.ToastManager.SetAnchor(point, x, y)
     ns.ToastManager.UpdatePositions()
 end
 
+function ns.ToastManager.ResetAnchor()
+    local db = ns.Addon.db.profile
+    db.display.anchorPoint = "RIGHT"
+    db.display.anchorX = -20
+    db.display.anchorY = 0
+    ns.ToastManager.SetAnchor("RIGHT", -20, 0)
+    ns.Print("Anchor position reset to default.")
+end
+
 -------------------------------------------------------------------------------
 -- Initialize
 -------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `ns.ToastManager.ResetAnchor()` function that resets anchor position to defaults (`RIGHT`, `-20`, `0`)
- Adds `/dt reset` slash command that calls `ResetAnchor()` and prints a confirmation message
- Updates help text to include the new reset command

Useful if the anchor gets dragged off-screen or the user wants to quickly restore the default position.