### PR TITLE
fix: resolve invisible toast and slide animation snap bugs

### DIFF
--- a/Display/ToastFrame.lua
+++ b/Display/ToastFrame.lua
@@ -468,6 +468,15 @@ function ns.ToastFrame.Release(frame)
     frame._entranceSlideY = nil
     frame._entranceFinalX = nil
     frame._entranceFinalY = nil
+    frame._isSliding = false
+    frame._slideStartTime = nil
+    frame._slideDuration = nil
+    frame._slideFromY = nil
+    frame._slideToY = nil
+    frame._slidePoint = nil
+    frame._slideRelativeTo = nil
+    frame._slideRelativePoint = nil
+    frame._slideX = nil
     frame:SetScript("OnUpdate", nil)
     frame:SetAlpha(1)
     frame:SetScale(1)

--- a/Display/ToastManager.lua
+++ b/Display/ToastManager.lua
@@ -108,31 +108,15 @@ function ns.ToastManager.UpdatePositions()
             toast._entranceFinalX = x
             toast._entranceFinalY = y
         else
-            -- Capture old position for smooth sliding
-            local oldY = 0
             local _, _, _, _, prevY = toast:GetPoint()
-            if prevY then
-                oldY = prevY
-            end
 
-            -- Capture remaining slide displacement before stopping
-            local slideRemainingY = 0
-            if toast:IsShown() and toast._slideTranslation
-                and toast.animGroups.slide:IsPlaying() then
-                local progress = toast._slideTranslation:GetSmoothProgress()
-                local _, oldOffsetY = toast._slideTranslation:GetOffset()
-                slideRemainingY = oldOffsetY * (1 - progress)
-            end
+            local alreadySlidingToTarget = toast._isSliding and toast._slideToY == y
 
-            toast:ClearAllPoints()
-            toast:SetPoint(point, relativeTo, relativePoint, x, y)
-
-            -- Animate existing (visible) toasts to new position
-            if toast:IsShown() and prevY and prevY ~= y then
-                local deltaY = (oldY - y) + slideRemainingY
-                if math.abs(deltaY) > 0.5 then
-                    ns.ToastAnimations.PlaySlide(toast, 0, deltaY)
-                end
+            if not alreadySlidingToTarget and toast:IsShown() and prevY and math.abs(prevY - y) > 0.5 then
+                ns.ToastAnimations.PlaySlide(toast, prevY, y, point, relativeTo, relativePoint, x)
+            elseif not alreadySlidingToTarget and not toast._isSliding then
+                toast:ClearAllPoints()
+                toast:SetPoint(point, relativeTo, relativePoint, x, y)
             end
         end
     end


### PR DESCRIPTION
## Summary

Fixes two display bugs in the toast animation system:

### Bug 1: Invisible Toast (rare)
**Root cause**: `SetToFinalAlpha(true)` on both entrance and exit animation groups retains alpha state after the group finishes. When a frame is recycled from the pool, `Stop()` on an already-finished exit group does not clear the retained alpha=0 state, causing the next entrance to play invisibly.

**Fix**: Remove `SetToFinalAlpha(true)` from both groups. Add an `OnFinished` callback to the entrance group that explicitly sets `frame:SetAlpha(1)` when the fade-in completes.

### Bug 2: List Bump/Jump
**Root cause**: The slide animation uses WoW's `Translation` type, which applies offset from 0→full over its duration. When it finishes, the offset is removed, snapping the frame back to its anchor. The animation effectively slides backwards (new→old) then snaps forward.

**Fix**: Replace the Translation-based slide with OnUpdate interpolation (same proven pattern used for entrance). This gives pixel-perfect `fromY→toY` interpolation with OUT easing and no snap on completion.

### Files Changed
- `Display/ToastAnimations.lua` — Remove SetToFinalAlpha, add OnFinished, remove Translation slide group, rewrite PlaySlide with OnUpdate, update StopAll
- `Display/ToastManager.lua` — Update UpdatePositions for new PlaySlide API (read current visual Y, skip if already sliding to target)
- `Display/ToastFrame.lua` — Add slide state field cleanup in Release