### PR TITLE
fix: include Libs/embeds.xml in git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 Libs/*
 !Libs/Ace3
 !Libs/LibAnimate
+!Libs/embeds.xml

--- a/Libs/embeds.xml
+++ b/Libs/embeds.xml
@@ -1,0 +1,39 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+
+	<!-- LibStub & CallbackHandler (foundation) -->
+	<Script file="Ace3\LibStub\LibStub.lua"/>
+	<Include file="Ace3\CallbackHandler-1.0\CallbackHandler-1.0.xml"/>
+
+	<!-- Ace3 libraries -->
+	<Include file="Ace3\AceAddon-3.0\AceAddon-3.0.xml"/>
+	<Include file="Ace3\AceEvent-3.0\AceEvent-3.0.xml"/>
+	<Include file="Ace3\AceTimer-3.0\AceTimer-3.0.xml"/>
+	<Include file="Ace3\AceBucket-3.0\AceBucket-3.0.xml"/>
+	<Include file="Ace3\AceHook-3.0\AceHook-3.0.xml"/>
+	<Include file="Ace3\AceDB-3.0\AceDB-3.0.xml"/>
+	<Include file="Ace3\AceDBOptions-3.0\AceDBOptions-3.0.xml"/>
+	<Include file="Ace3\AceLocale-3.0\AceLocale-3.0.xml"/>
+	<Include file="Ace3\AceConsole-3.0\AceConsole-3.0.xml"/>
+	<Include file="Ace3\AceGUI-3.0\AceGUI-3.0.xml"/>
+	<Include file="Ace3\AceConfig-3.0\AceConfig-3.0.xml"/>
+	<Include file="Ace3\AceComm-3.0\AceComm-3.0.xml"/>
+	<Include file="Ace3\AceTab-3.0\AceTab-3.0.xml"/>
+	<Include file="Ace3\AceSerializer-3.0\AceSerializer-3.0.xml"/>
+
+	<!-- LibDataBroker -->
+	<Script file="LibDataBroker-1.1\LibDataBroker-1.1.lua"/>
+
+	<!-- LibDBIcon -->
+	<Include file="LibDBIcon-1.0\lib.xml"/>
+
+	<!-- LibSharedMedia -->
+	<Include file="LibSharedMedia-3.0\lib.xml"/>
+
+	<!-- AceGUI SharedMedia Widgets -->
+	<Include file="AceGUI-3.0-SharedMediaWidgets\widget.xml"/>
+
+	<!-- LibAnimate -->
+	<Include file="LibAnimate\lib.xml"/>
+
+</Ui>


### PR DESCRIPTION
## Summary

`Libs/embeds.xml` was gitignored by the `Libs/*` rule, causing it to be missing from packaged releases. Libraries failed to load in-game from CurseForge/Wago downloads.

## Changes

- Added `!Libs/embeds.xml` exception to `.gitignore`
- Created `Libs/embeds.xml` with all library includes in correct load order:
  - LibStub & CallbackHandler (foundation)
  - Ace3 libraries (AceAddon, AceEvent, AceTimer, AceBucket, AceHook, AceDB, AceDBOptions, AceLocale, AceConsole, AceGUI, AceConfig, AceComm, AceTab, AceSerializer)
  - LibDataBroker-1.1
  - LibDBIcon-1.0
  - LibSharedMedia-3.0
  - AceGUI-3.0-SharedMediaWidgets
  - LibAnimate