### PR TITLE
fix: consolidate duplicates, optimize pooling, and improve code quality

### DIFF
--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -70,6 +70,27 @@ function ns.DebugPrint(msg)
 end
 
 -------------------------------------------------------------------------------
+-- Utility: Number formatting (shared across modules)
+-------------------------------------------------------------------------------
+
+function ns.FormatNumber(num)
+    if num >= 1000000 then
+        local divided = num / 1000000
+        if math.floor(divided) == divided then
+            return string.format("%dM", divided)
+        end
+        return string.format("%.1fM", divided)
+    elseif num >= 1000 then
+        local divided = num / 1000
+        if math.floor(divided) == divided then
+            return string.format("%dK", divided)
+        end
+        return string.format("%.1fK", divided)
+    end
+    return tostring(num)
+end
+
+-------------------------------------------------------------------------------
 -- AceAddon Lifecycle
 -------------------------------------------------------------------------------
 

--- a/Display/ToastFrame.lua
+++ b/Display/ToastFrame.lua
@@ -442,10 +442,15 @@ function ns.ToastFrame.Acquire()
     if not frame then
         frame = CreateToastFrame()
     end
+    frame._isPooled = false
     return frame
 end
 
 function ns.ToastFrame.Release(frame)
+    -- O(1) duplication guard
+    if frame._isPooled then return end
+    frame._isPooled = true
+
     -- Cancel any pending no-anim timer before releasing
     if frame._noAnimTimer then
         ns.Addon:CancelTimer(frame._noAnimTimer)
@@ -466,10 +471,6 @@ function ns.ToastFrame.Release(frame)
     frame:SetAlpha(1)
     frame:SetScale(1)
 
-    -- Pool duplication guard
-    for _, pooled in ipairs(framePool) do
-        if pooled == frame then return end
-    end
     table.insert(framePool, frame)
 end
 

--- a/Display/ToastManager.lua
+++ b/Display/ToastManager.lua
@@ -215,16 +215,11 @@ local function FindDuplicate(lootData)
 end
 
 -------------------------------------------------------------------------------
--- Utilities
+-- Utilities (delegates to shared ns.FormatNumber)
 -------------------------------------------------------------------------------
 
-function ns.ToastManager.FormatNumber(num)
-    if num >= 1000000 then
-        return string.format("%.1fM", num / 1000000)
-    elseif num >= 1000 then
-        return string.format("%.1fK", num / 1000)
-    end
-    return tostring(num)
+ns.ToastManager.FormatNumber = function(num)
+    return ns.FormatNumber(num)
 end
 
 -------------------------------------------------------------------------------

--- a/Listeners/LootListener_Retail.lua
+++ b/Listeners/LootListener_Retail.lua
@@ -210,33 +210,25 @@ local function OnChatMsgLoot(_, msg)
         quantity = tonumber(quantity) or 1
         isSelf = true
         looter = UnitName("player")
-    end
-
     -- Self-loot
-    if not itemLink then
+    elseif msg:match(PATTERN_LOOT_SELF) then
         itemLink = msg:match(PATTERN_LOOT_SELF)
-        if itemLink then
-            quantity = 1
-            isSelf = true
-            looter = UnitName("player")
-        end
-    end
-
-    -- Other-loot with quantity
-    if not itemLink then
+        quantity = 1
+        isSelf = true
+        looter = UnitName("player")
+    else
+        -- Other-loot with quantity
         looter, itemLink, quantity = msg:match(PATTERN_LOOT_OTHER_MULTI)
         if itemLink then
             quantity = tonumber(quantity) or 1
             isSelf = false
-        end
-    end
-
-    -- Other-loot
-    if not itemLink then
-        looter, itemLink = msg:match(PATTERN_LOOT_OTHER)
-        if itemLink then
-            quantity = 1
-            isSelf = false
+        else
+            -- Other-loot
+            looter, itemLink = msg:match(PATTERN_LOOT_OTHER)
+            if itemLink then
+                quantity = 1
+                isSelf = false
+            end
         end
     end
 

--- a/Listeners/LootListener_TBC.lua
+++ b/Listeners/LootListener_TBC.lua
@@ -199,33 +199,25 @@ local function OnChatMsgLoot(_, msg)
         quantity = tonumber(quantity) or 1
         isSelf = true
         looter = UnitName("player")
-    end
-
     -- Try self-loot without quantity
-    if not itemLink then
+    elseif msg:match(PATTERN_LOOT_SELF) then
         itemLink = msg:match(PATTERN_LOOT_SELF)
-        if itemLink then
-            quantity = 1
-            isSelf = true
-            looter = UnitName("player")
-        end
-    end
-
-    -- Try other-loot with quantity
-    if not itemLink then
+        quantity = 1
+        isSelf = true
+        looter = UnitName("player")
+    else
+        -- Try other-loot with quantity
         looter, itemLink, quantity = msg:match(PATTERN_LOOT_OTHER_MULTI)
         if itemLink then
             quantity = tonumber(quantity) or 1
             isSelf = false
-        end
-    end
-
-    -- Try other-loot without quantity
-    if not itemLink then
-        looter, itemLink = msg:match(PATTERN_LOOT_OTHER)
-        if itemLink then
-            quantity = 1
-            isSelf = false
+        else
+            -- Try other-loot without quantity
+            looter, itemLink = msg:match(PATTERN_LOOT_OTHER)
+            if itemLink then
+                quantity = 1
+                isSelf = false
+            end
         end
     end
 

--- a/Listeners/XPListener.lua
+++ b/Listeners/XPListener.lua
@@ -148,19 +148,6 @@ local function ParseXPText(text)
 end
 
 -------------------------------------------------------------------------------
--- Number Formatting
--------------------------------------------------------------------------------
-
-local function FormatNumber(num)
-    if num >= 1000000 then
-        return string_format("%.1fM", num / 1000000)
-    elseif num >= 1000 then
-        return string_format("%.1fK", num / 1000)
-    end
-    return tostring(num)
-end
-
--------------------------------------------------------------------------------
 -- Event Handler
 -------------------------------------------------------------------------------
 
@@ -177,7 +164,7 @@ local function OnChatMsgCombatXPGain(_event, text)
         xpAmount = xpAmount,
         mobName = mobName,
         itemIcon = XP_ICON,
-        itemName = "+" .. FormatNumber(xpAmount) .. " XP",
+        itemName = "+" .. ns.FormatNumber(xpAmount) .. " XP",
         itemQuality = XP_QUALITY,
         itemLevel = 0,
         itemType = nil,
@@ -196,7 +183,7 @@ end
 -- Public Interface
 -------------------------------------------------------------------------------
 
-ns.XPListener = {}
+ns.XPListener = ns.XPListener or {}
 
 function ns.XPListener.Initialize(addon)
     InitPatterns()


### PR DESCRIPTION
## Summary
- Extract shared `FormatNumber` utility to `Core/Init.lua`, removing duplicate implementations from `ToastManager` and `XPListener`
- Improve `FormatNumber` to omit unnecessary `.0` decimals (e.g. `1K` instead of `1.0K`)
- Use defensive initialization (`ns.XPListener = ns.XPListener or {}`) to prevent table overwrites
- Replace O(n) frame pool duplication guard with O(1) `_isPooled` flag check in `ToastFrame.lua`
- Refactor loot message matching to `if-elseif` chains in both Retail and TBC listeners