### PR TITLE
fix: remove unused string_format variable in XPListener

### DIFF
--- a/Listeners/XPListener.lua
+++ b/Listeners/XPListener.lua
@@ -15,7 +15,6 @@ local GetTime = GetTime
 local UnitName = UnitName
 local tonumber = tonumber
 local string_match = string.match
-local string_format = string.format
 
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove unused `string_format` cached variable in `XPListener.lua` (lint warning W211)
- This was left over from the `FormatNumber` consolidation in #51