### PR TITLE
feat: DragonLoot cross-addon bridge via AceEvent messaging

### DIFF
--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -135,6 +135,11 @@ function Addon:OnEnable()
     if ns.HonorListener.Initialize then
         ns.HonorListener.Initialize(self)
     end
+
+    -- Initialize DragonLoot bridge (optional cross-addon integration)
+    if ns.DragonLootBridge and ns.DragonLootBridge.Initialize then
+        ns.DragonLootBridge.Initialize(self)
+    end
 end
 
 function Addon:OnDisable()
@@ -151,6 +156,11 @@ function Addon:OnDisable()
     -- Shutdown Honor listener
     if ns.HonorListener.Shutdown then
         ns.HonorListener.Shutdown()
+    end
+
+    -- Shutdown DragonLoot bridge
+    if ns.DragonLootBridge and ns.DragonLootBridge.Shutdown then
+        ns.DragonLootBridge.Shutdown()
     end
 
     -- Clear all toasts

--- a/Display/ToastManager.lua
+++ b/Display/ToastManager.lua
@@ -306,6 +306,15 @@ function ns.ToastManager.QueueToast(lootData)
     local db = ns.Addon.db.profile
     if not db.enabled then return end
 
+    -- Suppress normal item toasts while DragonLoot loot window is open
+    if ns.dragonLootSuppressLoot
+        and not lootData.isXP
+        and not lootData.isHonor
+        and not lootData.isCurrency
+        and not lootData.isRollWin then
+        return
+    end
+
     -- Combat deferral
     if db.combat.deferInCombat and InCombatLockdown() then
         QueuePush(combatQueue, lootData)

--- a/DragonToast.toc
+++ b/DragonToast.toc
@@ -42,3 +42,4 @@ Listeners\LootListener_Retail.lua
 # Shared listeners
 Listeners\XPListener.lua
 Listeners\HonorListener.lua
+Listeners\DragonLootBridge.lua

--- a/Listeners/DragonLootBridge.lua
+++ b/Listeners/DragonLootBridge.lua
@@ -1,0 +1,118 @@
+-------------------------------------------------------------------------------
+-- DragonLootBridge.lua
+-- Cross-addon messaging bridge for DragonLoot integration
+--
+-- Supported versions: TBC Anniversary, Retail, MoP Classic
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+
+-------------------------------------------------------------------------------
+-- Cached WoW API
+-------------------------------------------------------------------------------
+
+local GetTime = GetTime
+local UnitName = UnitName
+local tonumber = tonumber
+
+-------------------------------------------------------------------------------
+-- Module
+-------------------------------------------------------------------------------
+
+ns.DragonLootBridge = ns.DragonLootBridge or {}
+
+-------------------------------------------------------------------------------
+-- Module-level state
+-------------------------------------------------------------------------------
+
+local suppressTimer
+
+-------------------------------------------------------------------------------
+-- Loot Suppression
+--
+-- When DragonLoot's loot window is open we suppress normal item toasts so the
+-- player does not see duplicate notifications. XP, honor, currency, and
+-- roll-win celebration toasts are still allowed through.
+-------------------------------------------------------------------------------
+
+local SUPPRESS_TIMEOUT = 120
+
+local function OnDragonLootOpened()
+    ns.dragonLootSuppressLoot = true
+    -- Safety timeout - clear if CLOSED never arrives (crash / reload)
+    if suppressTimer then ns.Addon:CancelTimer(suppressTimer) end
+    suppressTimer = ns.Addon:ScheduleTimer(function()
+        if ns.dragonLootSuppressLoot then
+            ns.dragonLootSuppressLoot = false
+            ns.DebugPrint("DragonLootBridge: safety timeout cleared suppress flag")
+        end
+        suppressTimer = nil
+    end, SUPPRESS_TIMEOUT)
+    ns.DebugPrint("DragonLoot loot window opened - suppressing item toasts")
+end
+
+local function OnDragonLootClosed()
+    ns.dragonLootSuppressLoot = false
+    if suppressTimer then
+        ns.Addon:CancelTimer(suppressTimer)
+        suppressTimer = nil
+    end
+    ns.DebugPrint("DragonLoot loot window closed - resuming item toasts")
+end
+
+-------------------------------------------------------------------------------
+-- Roll-Won Celebration Toast
+--
+-- Fired when the player wins a roll in DragonLoot. We build a lootData table
+-- compatible with ToastManager.QueueToast and flag it with isRollWin so
+-- DragonToast can optionally render it differently.
+-------------------------------------------------------------------------------
+
+local function OnDragonLootRollWon(_event, rollData)
+    if not rollData then return end
+
+    local db = ns.Addon.db.profile
+    if not db.enabled then return end
+
+    local lootData = {
+        isRollWin = true,
+        itemLink = rollData.itemLink,
+        itemID = rollData.itemID or (rollData.itemLink and tonumber(rollData.itemLink:match("item:(%d+)"))),
+        itemName = rollData.itemName or UNKNOWN,
+        itemQuality = rollData.itemQuality or 1,
+        itemIcon = rollData.itemIcon,
+        itemLevel = 0,
+        itemType = rollData.rollType or "Roll",
+        itemSubType = nil,
+        quantity = rollData.quantity or 1,
+        looter = UnitName("player") or "You",
+        isSelf = true,
+        isCurrency = false,
+        timestamp = GetTime(),
+    }
+
+    ns.ToastManager.QueueToast(lootData)
+end
+
+-------------------------------------------------------------------------------
+-- Public Interface
+-------------------------------------------------------------------------------
+
+function ns.DragonLootBridge.Initialize(addon)
+    addon:RegisterMessage("DRAGONLOOT_LOOT_OPENED", OnDragonLootOpened)
+    addon:RegisterMessage("DRAGONLOOT_LOOT_CLOSED", OnDragonLootClosed)
+    addon:RegisterMessage("DRAGONLOOT_ROLL_WON", OnDragonLootRollWon)
+    ns.DebugPrint("DragonLootBridge initialized")
+end
+
+function ns.DragonLootBridge.Shutdown()
+    ns.dragonLootSuppressLoot = false
+    if suppressTimer then
+        ns.Addon:CancelTimer(suppressTimer)
+        suppressTimer = nil
+    end
+    ns.Addon:UnregisterMessage("DRAGONLOOT_LOOT_OPENED")
+    ns.Addon:UnregisterMessage("DRAGONLOOT_LOOT_CLOSED")
+    ns.Addon:UnregisterMessage("DRAGONLOOT_ROLL_WON")
+    ns.DebugPrint("DragonLootBridge shutdown")
+end


### PR DESCRIPTION
## DragonLoot Integration

Adds cross-addon AceEvent messaging bridge for integration with the DragonLoot addon. Neither addon requires the other - both work independently.

### New File
- **Listeners/DragonLootBridge.lua** - Registers for DragonLoot's AceEvent messages

### Messages Handled
| Message | Behavior |
|---------|----------|
| DRAGONLOOT_LOOT_OPENED | Suppress item loot toasts (DragonLoot shows its own loot UI) |
| DRAGONLOOT_LOOT_CLOSED | Resume normal toast behavior |
| DRAGONLOOT_ROLL_WON | Show celebration toast when player wins a roll |

### Suppression Details
- Only item loot toasts are suppressed while DragonLoot's loot window is open
- XP, honor, currency, and roll-won toasts always pass through
- 120-second safety timer auto-clears suppression if CLOSED message never arrives (crash/reload safety)

### Modified Files
- **Display/ToastManager.lua** - Added suppression check in QueueToast
- **Core/Init.lua** - Bridge initialization/shutdown
- **DragonToast.toc** - Added bridge file to load order

### Design
- Zero coupling: DragonToast does not import or reference DragonLoot
- Uses AceEvent RegisterMessage/UnregisterMessage for cross-addon message bus
- Follows existing listener patterns (Initialize/Shutdown lifecycle)
- Degrades gracefully: if DragonLoot is not installed, registered messages never fire

Luacheck: 0 warnings / 0 errors