### PR TITLE
feat: enhanced roll-won toast with winner name and roll details

### DIFF
--- a/Listeners/DragonLootBridge.lua
+++ b/Listeners/DragonLootBridge.lua
@@ -68,11 +68,21 @@ end
 -- DragonToast can optionally render it differently.
 -------------------------------------------------------------------------------
 
+-- Map numeric roll types to display names
+local rollTypeNames = { [0] = "Pass", [1] = "Need", [2] = "Greed", [3] = "Disenchant", [4] = "Transmog" }
+
 local function OnDragonLootRollWon(_event, rollData)
     if not rollData then return end
 
     local db = ns.Addon.db.profile
     if not db.enabled then return end
+
+    -- Build human-readable roll display (e.g. "Need (87)")
+    local rollTypeName = rollTypeNames[rollData.rollType] or "Roll"
+    local rollDisplay = rollTypeName
+    if rollData.rollValue then
+        rollDisplay = rollTypeName .. " (" .. rollData.rollValue .. ")"
+    end
 
     local lootData = {
         isRollWin = true,
@@ -82,11 +92,11 @@ local function OnDragonLootRollWon(_event, rollData)
         itemQuality = rollData.itemQuality or 1,
         itemIcon = rollData.itemIcon,
         itemLevel = 0,
-        itemType = rollData.rollType or "Roll",
+        itemType = rollDisplay,
         itemSubType = nil,
         quantity = rollData.quantity or 1,
-        looter = UnitName("player") or "You",
-        isSelf = true,
+        looter = rollData.winnerName or UnitName("player") or "You",
+        isSelf = rollData.isSelf ~= false, -- default true for backward compat
         isCurrency = false,
         timestamp = GetTime(),
     }


### PR DESCRIPTION
## Roll-Won Toast Enhancement

Updates the DragonLoot bridge to handle the enhanced DRAGONLOOT_ROLL_WON payload.

### Changes
- **Winner name**: Toast now shows actual winner name (winnerName field) instead of always assuming local player
- **Roll details**: Toast type line shows descriptive text like 'Need (87)' instead of raw rollType number
- **Group support**: isSelf flag from payload controls whether looter is shown as self or group member
- **Backward compatible**: All new fields have fallbacks for older DragonLoot versions (winnerName falls back to UnitName, isSelf defaults to true when nil)

### Updated Payload Fields Used
| Field | Usage |
|-------|-------|
| winnerName | Sets looter display name |
| winnerClass | Available for future class-colored display |
| rollType | Mapped to human-readable name (Need/Greed/Disenchant/Transmog) |
| rollValue | Appended as dice number e.g. 'Need (87)' |
| isSelf | Controls self vs group member toast display |

Luacheck: 0 warnings / 0 errors