### PR TITLE
fix: resolve minimap icon toggle inverted logic

### DIFF
--- a/Core/Config.lua
+++ b/Core/Config.lua
@@ -161,9 +161,8 @@ local function GetOptions()
                         order = 3,
                         get = function() return not db.minimap.hide end,
                         set = function(_, val)
-                            db.minimap.hide = not val
-                            if ns.MinimapIcon.Toggle then
-                                ns.MinimapIcon.Toggle()
+                            if ns.MinimapIcon.SetShown then
+                                ns.MinimapIcon.SetShown(val)
                             end
                         end,
                     },

--- a/Core/MinimapIcon.lua
+++ b/Core/MinimapIcon.lua
@@ -87,17 +87,16 @@ function ns.MinimapIcon.Initialize()
     ns.DebugPrint("Minimap icon initialized")
 end
 
-function ns.MinimapIcon.Toggle()
+function ns.MinimapIcon.SetShown(shown)
     local LDBIcon = LibStub("LibDBIcon-1.0", true)
     if not LDBIcon then return end
 
     local db = ns.Addon.db.profile.minimap
-    if db.hide then
+    db.hide = not shown
+    if shown then
         LDBIcon:Show("DragonToast")
-        db.hide = false
     else
         LDBIcon:Hide("DragonToast")
-        db.hide = true
     end
 end
 


### PR DESCRIPTION
## Problem

When the user toggled "Show Minimap Icon" in the config UI, the icon did the **opposite** of what was selected.

**Root cause**: The Config setter set `db.minimap.hide = not val`, then called `MinimapIcon.Toggle()`. But `Toggle()` read the already-updated `db.hide` value and flipped it again, undoing the config change.

## Fix

- Replaced `Toggle()` with `SetShown(shown)` in `MinimapIcon.lua` — an idempotent function that takes an explicit boolean, sets `db.hide` accordingly, and calls the matching `LDBIcon:Show/Hide`
- Simplified the Config setter to delegate entirely to `SetShown(val)`, eliminating the double-flip

## Testing

1. `/dt config` → toggle "Show Minimap Icon" on and off — icon visibility should match checkbox
2. `/reload` — saved state persists correctly
3. `luacheck Core/MinimapIcon.lua Core/Config.lua` — passes with no warnings