### PR TITLE
fix: rework toast frame layout with child-frame hierarchy

### DIFF
--- a/Core/Config.lua
+++ b/Core/Config.lua
@@ -587,7 +587,7 @@ local function GetOptions()
                         set = function(_, val) db.animation.holdDuration = val end,
                     },
                     exitDuration = {
-                        name = "Fade Out Duration",
+                        name = "Exit Duration",
                         desc = "How long the fade-out takes (seconds).",
                         type = "range",
                         order = 13,

--- a/Display/ElvUISkin.lua
+++ b/Display/ElvUISkin.lua
@@ -82,7 +82,7 @@ function ns.ElvUISkin.SkinToast(frame)
     if not db.appearance.qualityBorder then
         local br, bg, bb, ba = ns.ElvUISkin.GetBorderColor()
         frame:SetBackdropBorderColor(br, bg, bb, ba)
-        frame.iconBorder:SetColorTexture(br, bg, bb, ba)
+        frame.iconFrame:SetBackdropBorderColor(br, bg, bb, ba)
     end
 end
 

--- a/DragonToast.toc
+++ b/DragonToast.toc
@@ -29,15 +29,12 @@ Display\ToastManager.lua
 Display\ElvUISkin.lua
 
 # Version-specific listeners
-#@retail@
-Listeners\LootListener_Retail.lua
-#@end-retail@
 #@tbc-anniversary@
 Listeners\LootListener_TBC.lua
 #@end-tbc-anniversary@
-#@version-mists@
+#@non-tbc-anniversary@
 Listeners\LootListener_Retail.lua
-#@end-version-mists@
+#@end-non-tbc-anniversary@
 
 # Shared listeners
 Listeners\XPListener.lua


### PR DESCRIPTION
## Changes

### Layout Rework
- Replace flat single-frame layout with nested child frames (content, iconFrame)
- Fix border/glow/icon z-fighting via proper frame level hierarchy
- Extract shared helpers (ApplyFonts, ApplyLayout, ApplyBackdrop, ApplyGlow)
- Eliminate ~200 lines of duplicate code across XP/Honor/Normal toast paths
- Update ElvUISkin iconBorder -> iconFrame migration

### Bug Fixes
- Fix GetBackdropKey nil crash when LSM:Fetch returns nil
- Fix lib:Stop() restoring stale anchor after SlideAnchor repositioning
- Fix deferred slide catch-up being a no-op between animations
- Fix premature _anchorY tracking in UpdatePositions entrance branch
- Fix mid-slide freeze caused by UpdateAnchor clobbering in-progress slides
- Fix content squish at large border sizes (use half-border inset)
- Fix border artifact at borderSize=0 (nil edgeFile to disable border)
- Fix TOC duplicate file load for LootListener_Retail.lua

### Config
- Rename 'Fade Out Duration' to 'Exit Duration'