### PR TITLE
fix: use faction-specific honor icon constants (closes #76)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -26,6 +26,7 @@ read_globals = {
 
     -- WoW API
     "CreateFrame", "GetTime", "IsInInstance", "UnitName", "UnitClass",
+    "UnitFactionGroup",
     "GetItemInfo", "GetItemQualityColor", "C_Timer", "C_Item", "C_Container",
     "GameTooltip", "UIParent", "PlaySound", "PlaySoundFile",
     "ChatFrame_OpenChat", "IsShiftKeyDown",
@@ -33,7 +34,7 @@ read_globals = {
     "InterfaceOptionsFrame_OpenToCategory", "Settings","GetTime",
 
     -- WoW Globals
-    "Enum", "RAID_CLASS_COLORS", "ITEM_QUALITY_COLORS", "STANDARD_TEXT_FONT",
+    "Constants", "Enum", "RAID_CLASS_COLORS", "ITEM_QUALITY_COLORS", "STANDARD_TEXT_FONT",
     "WOW_PROJECT_ID", "WOW_PROJECT_MAINLINE",
     "WOW_PROJECT_BURNING_CRUSADE_CLASSIC", "WOW_PROJECT_MISTS_CLASSIC",
     "LOOT_ITEM_SELF", "LOOT_ITEM_SELF_MULTIPLE",

--- a/Display/ToastManager.lua
+++ b/Display/ToastManager.lua
@@ -420,7 +420,8 @@ function ns.ToastManager.ShowTestToast()
         { name = "+1,234 XP", quality = 1, level = 0, type = nil, subType = nil,
           icon = 894556, id = 99999, isXP = true, xpAmount = 1234 },
         { name = "+150 Honor", quality = 1, level = 0, type = nil, subType = nil,
-          icon = 1455894, id = 99997, isHonor = true, honorAmount = 150, victimName = "Enemy Player" },
+          icon = ns.HonorListener.GetHonorIcon(), id = 99997, isHonor = true, honorAmount = 150,
+          victimName = "Enemy Player" },
     }
 
     local test = testItems[math.random(#testItems)]


### PR DESCRIPTION
## Summary
Fixes #76 - Honor toast shows green square instead of honor icon on Classic (TBC Anniversary / MoP Classic).

## Root Cause
`HONOR_ICON = 1455894` is a numeric FileDataID for `Achievement_LegionPVPTier4`. Classic clients don't have this ID in their ArtTextureID mapping, so the texture can't be resolved and WoW renders a green square.

## Fix
Replace the hardcoded numeric ID with Blizzard's built-in faction-specific honor icon constants:
- `Constants.CurrencyConsts.PVP_CURRENCY_HONOR_ALLIANCE_INV_ICON` (463450)
- `Constants.CurrencyConsts.PVP_CURRENCY_HONOR_HORDE_INV_ICON` (463451)

These are resolved at addon initialization via `UnitFactionGroup('player')`, with a string texture path fallback (`Interface\Icons\Achievement_LegionPVPTier4`) for safety.

## Changes
- `Listeners/HonorListener.lua`: Added `ResolveHonorIcon()` function and `GetHonorIcon()` public accessor
- `Display/ToastManager.lua`: Test toast uses `ns.HonorListener.GetHonorIcon()` instead of hardcoded ID
- `.luacheckrc`: Added `UnitFactionGroup` and `Constants` to read_globals

## Testing
- `/dt test` repeatedly until honor toast appears - should show faction-appropriate honor icon
- `/dt testmode` - honor toasts in rotation should display correctly
- Verify on both Alliance and Horde characters if possible