### PR TITLE
fix: stacking accumulation bugs and add busted unit tests

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,0 +1,10 @@
+return {
+    _all = {
+        lua = "lua",
+    },
+    default = {
+        ROOT = { "spec" },
+        pattern = "_spec",
+        verbose = true,
+    },
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,3 +15,17 @@ jobs:
       - uses: nebularg/actions-luacheck@v1
         with:
           args: --no-color
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: "5.1"
+      - uses: leafo/gh-actions-luarocks@v4
+      - run: luarocks install busted
+      - name: Run tests
+        run: busted --verbose

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -62,3 +62,14 @@ read_globals = {
     -- ElvUI
     "ElvUI",
 }
+
+files = {
+    ["spec/**"] = {
+        std = "+busted",
+        globals = {
+            -- WoW API mocks (set as globals in wow_mock.lua)
+            "GetTime", "InCombatLockdown", "PlaySoundFile", "UnitName",
+            "GetCoinTextureString", "CreateFrame", "UIParent", "LibStub", "wipe",
+        },
+    },
+}

--- a/Core/SlashCommands.lua
+++ b/Core/SlashCommands.lua
@@ -67,6 +67,11 @@ local function PrintHelp()
     print("  " .. ns.COLOR_WHITE .. "/dt config" .. ns.COLOR_RESET .. " — Open settings panel")
     print("  " .. ns.COLOR_WHITE .. "/dt lock" .. ns.COLOR_RESET .. " — Toggle anchor lock (drag to move)")
     print("  " .. ns.COLOR_WHITE .. "/dt test" .. ns.COLOR_RESET .. " — Show a test toast")
+    print("  " .. ns.COLOR_WHITE .. "/dt test stack" .. ns.COLOR_RESET .. " -- Test item stacking (3 rapid items)")
+    print("  " .. ns.COLOR_WHITE .. "/dt test xp" .. ns.COLOR_RESET .. " -- Test XP accumulation")
+    print("  " .. ns.COLOR_WHITE .. "/dt test gold" .. ns.COLOR_RESET .. " -- Test gold accumulation")
+    print("  " .. ns.COLOR_WHITE .. "/dt test honor" .. ns.COLOR_RESET .. " -- Test honor accumulation")
+    print("  " .. ns.COLOR_WHITE .. "/dt test all" .. ns.COLOR_RESET .. " -- Run all stacking tests")
     print("  " .. ns.COLOR_WHITE .. "/dt testmode" .. ns.COLOR_RESET .. " — Toggle continuous test toast generation")
     print("  " .. ns.COLOR_WHITE .. "/dt clear" .. ns.COLOR_RESET .. " — Dismiss all toasts")
     print("  " .. ns.COLOR_WHITE .. "/dt reset" .. ns.COLOR_RESET .. " — Reset anchor position to default")
@@ -103,9 +108,11 @@ function ns.HandleSlashCommand(input)
         ns.ToastManager.ToggleLock()
 
     elseif cmd == "test" then
-        if ns.ToastManager.ShowTestToast then
-            ns.ToastManager.ShowTestToast()
-        end
+        ns.ToastManager.ShowTestToast()
+
+    elseif cmd:find("^test ") then
+        local subCmd = cmd:match("^test (.+)$")
+        ns.ToastManager.RunStackTest(subCmd)
 
     elseif cmd == "testmode" then
         ns.ToastManager.ToggleTestMode()

--- a/_run_tests.ps1
+++ b/_run_tests.ps1
@@ -1,0 +1,51 @@
+#!/usr/bin/env pwsh
+# _run_tests.ps1 - Run the DragonToast busted test suite.
+# Sets up Lua paths from luarocks and runs busted with any extra arguments.
+# Usage: .\_run_tests.ps1 [busted args...]
+# Examples: .\_run_tests.ps1 --verbose
+#           .\_run_tests.ps1 --filter "gold"
+
+param(
+    [Parameter(ValueFromRemainingArguments)]
+    [string[]]$BustedArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# --- Preflight checks -------------------------------------------------------
+
+if (-not (Get-Command lua -ErrorAction SilentlyContinue)) {
+    Write-Error "lua not found on PATH. Install Lua (e.g. scoop install lua)."
+    exit 1
+}
+
+if (-not (Get-Command luarocks -ErrorAction SilentlyContinue)) {
+    Write-Error "luarocks not found on PATH. Install luarocks (e.g. scoop install luarocks)."
+    exit 1
+}
+
+if (-not (Get-Command busted -ErrorAction SilentlyContinue)) {
+    Write-Error "busted not found on PATH. Install it with: luarocks install busted"
+    exit 1
+}
+
+# --- Set up Lua paths from luarocks -----------------------------------------
+
+# luarocks path outputs SET statements like: SET "LUA_PATH=..." and SET "LUA_CPATH=..."
+# Parse and apply them as process-level environment variables so lua can find rocks.
+foreach ($line in (& luarocks path 2>&1)) {
+    if ("$line" -match '^SET "(\w+)=(.+)"$') {
+        [System.Environment]::SetEnvironmentVariable($Matches[1], $Matches[2].TrimEnd('"'), 'Process')
+    }
+}
+
+if (-not $env:LUA_PATH) {
+    Write-Error "Failed to parse LUA_PATH from 'luarocks path' output."
+    exit 1
+}
+
+# --- Run busted --------------------------------------------------------------
+
+& busted @($BustedArgs ?? @())
+exit $LASTEXITCODE

--- a/spec/ToastManager_spec.lua
+++ b/spec/ToastManager_spec.lua
@@ -1,0 +1,533 @@
+-------------------------------------------------------------------------------
+-- ToastManager_spec.lua
+-- Unit tests for ToastManager stacking, queue, and dedup logic
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+-- Load the module under test
+local ns = mock.CreateNamespace()
+local TM = mock.LoadToastManager(ns)
+local T  -- _test internals (assigned after Initialize)
+
+-------------------------------------------------------------------------------
+-- Test helpers
+-------------------------------------------------------------------------------
+
+local function makeItemData(overrides)
+    local data = {
+        itemID = 32837,
+        itemName = "Warglaive of Azzinoth",
+        itemQuality = 5,
+        itemLevel = 156,
+        itemType = "Weapon",
+        itemSubType = "Sword",
+        itemIcon = 135562,
+        quantity = 1,
+        looter = "TestPlayer",
+        isSelf = true,
+        isCurrency = false,
+        timestamp = GetTime(),
+    }
+    if overrides then
+        for k, v in pairs(overrides) do data[k] = v end
+    end
+    return data
+end
+
+local function makeXPData(overrides)
+    local data = {
+        isXP = true,
+        xpAmount = 500,
+        itemIcon = 894556,
+        itemName = "+500 XP",
+        itemQuality = 1,
+        itemLevel = 0,
+        quantity = 1,
+        looter = "TestPlayer",
+        isSelf = true,
+        isCurrency = false,
+        timestamp = GetTime(),
+    }
+    if overrides then
+        for k, v in pairs(overrides) do data[k] = v end
+    end
+    return data
+end
+
+local function makeHonorData(overrides)
+    local data = {
+        isHonor = true,
+        honorAmount = 100,
+        victimName = "Enemy Player",
+        itemIcon = 463450,
+        itemName = "+100 Honor",
+        itemQuality = 1,
+        itemLevel = 0,
+        quantity = 1,
+        looter = "TestPlayer",
+        isSelf = true,
+        isCurrency = false,
+        timestamp = GetTime(),
+    }
+    if overrides then
+        for k, v in pairs(overrides) do data[k] = v end
+    end
+    return data
+end
+
+local function makeGoldData(overrides)
+    local data = {
+        itemLink = nil,
+        itemID = nil,
+        copperAmount = 50000,
+        itemName = "50000c",
+        itemQuality = 1,
+        itemLevel = 0,
+        itemType = "Currency",
+        itemSubType = "Gold",
+        itemIcon = 133784,
+        quantity = 1,
+        looter = "TestPlayer",
+        isSelf = true,
+        isCurrency = true,
+        timestamp = GetTime(),
+    }
+    if overrides then
+        for k, v in pairs(overrides) do data[k] = v end
+    end
+    return data
+end
+
+local function makeCurrencyData(overrides)
+    local data = {
+        itemID = 99999,
+        itemName = "Valor Points",
+        itemQuality = 1,
+        itemIcon = 123456,
+        quantity = 1,
+        looter = "TestPlayer",
+        isSelf = true,
+        isCurrency = true,
+        timestamp = GetTime(),
+    }
+    if overrides then
+        for k, v in pairs(overrides) do data[k] = v end
+    end
+    return data
+end
+
+-------------------------------------------------------------------------------
+-- Setup
+-------------------------------------------------------------------------------
+
+describe("ToastManager", function()
+
+    setup(function()
+        -- Initialize once (creates anchor frame, sets isInitialized)
+        TM.Initialize()
+        T = TM._test
+    end)
+
+    before_each(function()
+        mock.Reset(ns)
+        mock.SetTime(100) -- Start at t=100 to avoid edge cases at 0
+    end)
+
+    -- =================================================================
+    -- Queue Helpers
+    -- =================================================================
+
+    describe("Queue helpers", function()
+
+        it("QueuePush adds items in order", function()
+            local q = { first = 1, last = 0 }
+            T.QueuePush(q, "a")
+            T.QueuePush(q, "b")
+            T.QueuePush(q, "c")
+            assert.equal(3, T.QueueSize(q))
+            assert.equal("a", q[1])
+            assert.equal("b", q[2])
+            assert.equal("c", q[3])
+        end)
+
+        it("QueuePop returns items in FIFO order", function()
+            local q = { first = 1, last = 0 }
+            T.QueuePush(q, "a")
+            T.QueuePush(q, "b")
+            T.QueuePush(q, "c")
+            assert.equal("a", T.QueuePop(q))
+            assert.equal("b", T.QueuePop(q))
+            assert.equal("c", T.QueuePop(q))
+        end)
+
+        it("QueuePop returns nil on empty queue", function()
+            local q = { first = 1, last = 0 }
+            assert.is_nil(T.QueuePop(q))
+        end)
+
+        it("QueueSize returns correct count", function()
+            local q = { first = 1, last = 0 }
+            assert.equal(0, T.QueueSize(q))
+            T.QueuePush(q, "a")
+            assert.equal(1, T.QueueSize(q))
+            T.QueuePush(q, "b")
+            assert.equal(2, T.QueueSize(q))
+            T.QueuePop(q)
+            assert.equal(1, T.QueueSize(q))
+        end)
+
+        it("QueueReset clears all entries", function()
+            local q = { first = 1, last = 0 }
+            T.QueuePush(q, "a")
+            T.QueuePush(q, "b")
+            T.QueueReset(q)
+            assert.equal(0, T.QueueSize(q))
+            assert.is_nil(T.QueuePop(q))
+        end)
+
+        it("Multiple push/pop cycles maintain FIFO", function()
+            local q = { first = 1, last = 0 }
+            T.QueuePush(q, 1)
+            T.QueuePush(q, 2)
+            assert.equal(1, T.QueuePop(q))
+            T.QueuePush(q, 3)
+            assert.equal(2, T.QueuePop(q))
+            assert.equal(3, T.QueuePop(q))
+            assert.is_nil(T.QueuePop(q))
+        end)
+
+    end)
+
+    -- =================================================================
+    -- FindDuplicate - Active toast matching
+    -- =================================================================
+
+    describe("FindDuplicate - active toasts", function()
+
+        it("returns nil when no active toasts exist", function()
+            assert.is_nil(T.FindDuplicate(makeItemData()))
+        end)
+
+        it("matches XP toast to active XP toast", function()
+            -- Create an active XP toast
+            T.ShowToast(makeXPData())
+            assert.equal(1, #T.activeToasts)
+
+            -- Second XP should find duplicate
+            local existing, idx = T.FindDuplicate(makeXPData())
+            assert.is_not_nil(existing)
+            assert.equal(1, idx)
+        end)
+
+        it("matches Honor toast to active Honor toast", function()
+            T.ShowToast(makeHonorData())
+            local existing, idx = T.FindDuplicate(makeHonorData())
+            assert.is_not_nil(existing)
+            assert.equal(1, idx)
+        end)
+
+        it("matches Gold toast to active Gold toast", function()
+            T.ShowToast(makeGoldData())
+            local existing, idx = T.FindDuplicate(makeGoldData())
+            assert.is_not_nil(existing)
+            assert.equal(1, idx)
+        end)
+
+        it("matches item by itemID and isSelf", function()
+            T.ShowToast(makeItemData())
+            local existing, idx = T.FindDuplicate(makeItemData())
+            assert.is_not_nil(existing)
+            assert.equal(1, idx)
+        end)
+
+        it("returns nil when timestamp exceeds DUPLICATE_WINDOW", function()
+            T.ShowToast(makeXPData())
+            mock.AdvanceTime(T.DUPLICATE_WINDOW + 0.1)
+            assert.is_nil(T.FindDuplicate(makeXPData()))
+        end)
+
+        it("returns nil when itemIDs differ", function()
+            T.ShowToast(makeItemData({ itemID = 111 }))
+            assert.is_nil(T.FindDuplicate(makeItemData({ itemID = 222 })))
+        end)
+
+        it("returns nil when isSelf differs", function()
+            T.ShowToast(makeItemData({ isSelf = true }))
+            assert.is_nil(T.FindDuplicate(makeItemData({ isSelf = false })))
+        end)
+
+        it("returns nil for non-gold currency", function()
+            assert.is_nil(T.FindDuplicate(makeCurrencyData()))
+        end)
+
+    end)
+
+    -- =================================================================
+    -- FindDuplicate - Queue matching
+    -- =================================================================
+
+    describe("FindDuplicate - queue matching", function()
+
+        it("merges XP in-place in toastQueue", function()
+            -- Fill active toasts to max so next goes to queue
+            ns.Addon.db.profile.display.maxToasts = 0
+            T.ShowToast(makeXPData({ xpAmount = 200 }))
+            assert.equal(1, T.QueueSize(T.toastQueue))
+
+            -- Second XP should merge in queue
+            local existing, idx = T.FindDuplicate(makeXPData({ xpAmount = 300 }))
+            assert.is_not_nil(existing)
+            assert.is_nil(idx) -- nil = queued
+            assert.equal(500, existing.xpAmount)
+
+            -- Restore
+            ns.Addon.db.profile.display.maxToasts = 5
+        end)
+
+        it("merges Honor in-place in toastQueue", function()
+            ns.Addon.db.profile.display.maxToasts = 0
+            T.ShowToast(makeHonorData({ honorAmount = 50 }))
+
+            local existing, idx = T.FindDuplicate(makeHonorData({ honorAmount = 75 }))
+            assert.is_not_nil(existing)
+            assert.is_nil(idx)
+            assert.equal(125, existing.honorAmount)
+
+            ns.Addon.db.profile.display.maxToasts = 5
+        end)
+
+        it("merges Gold in-place in toastQueue", function()
+            ns.Addon.db.profile.display.maxToasts = 0
+            T.ShowToast(makeGoldData({ copperAmount = 10000 }))
+
+            local existing, idx = T.FindDuplicate(makeGoldData({ copperAmount = 20000 }))
+            assert.is_not_nil(existing)
+            assert.is_nil(idx)
+            assert.equal(30000, existing.copperAmount)
+
+            ns.Addon.db.profile.display.maxToasts = 5
+        end)
+
+        it("merges item quantity in-place in toastQueue", function()
+            ns.Addon.db.profile.display.maxToasts = 0
+            T.ShowToast(makeItemData({ quantity = 2 }))
+
+            local existing, idx = T.FindDuplicate(makeItemData({ quantity = 3 }))
+            assert.is_not_nil(existing)
+            assert.is_nil(idx)
+            assert.equal(5, existing.quantity)
+
+            ns.Addon.db.profile.display.maxToasts = 5
+        end)
+
+        it("merges in combatQueue when not in toastQueue", function()
+            -- Put item in combat queue
+            T.QueuePush(T.combatQueue, makeItemData({ quantity = 1 }))
+
+            local existing, idx = T.FindDuplicate(makeItemData({ quantity = 2 }))
+            assert.is_not_nil(existing)
+            assert.is_nil(idx)
+            assert.equal(3, existing.quantity)
+        end)
+
+        it("returns nil index for queue matches", function()
+            ns.Addon.db.profile.display.maxToasts = 0
+            T.ShowToast(makeXPData())
+
+            local _, idx = T.FindDuplicate(makeXPData())
+            assert.is_nil(idx)
+
+            ns.Addon.db.profile.display.maxToasts = 5
+        end)
+
+    end)
+
+    -- =================================================================
+    -- ShowToast - Stacking on active toasts
+    -- =================================================================
+
+    describe("ShowToast - stacking", function()
+
+        it("stacks XP: sums xpAmount and updates itemName", function()
+            T.ShowToast(makeXPData({ xpAmount = 200 }))
+            assert.equal(1, #T.activeToasts)
+
+            T.ShowToast(makeXPData({ xpAmount = 300 }))
+            assert.equal(1, #T.activeToasts) -- still 1 toast
+            assert.equal(500, T.activeToasts[1].lootData.xpAmount)
+            assert.truthy(T.activeToasts[1].lootData.itemName:find("500"))
+        end)
+
+        it("stacks Honor: sums honorAmount and updates itemName", function()
+            T.ShowToast(makeHonorData({ honorAmount = 50 }))
+            T.ShowToast(makeHonorData({ honorAmount = 75 }))
+            assert.equal(1, #T.activeToasts)
+            assert.equal(125, T.activeToasts[1].lootData.honorAmount)
+            assert.truthy(T.activeToasts[1].lootData.itemName:find("125"))
+        end)
+
+        it("stacks Gold: sums copperAmount", function()
+            T.ShowToast(makeGoldData({ copperAmount = 10000 }))
+            T.ShowToast(makeGoldData({ copperAmount = 20000 }))
+            assert.equal(1, #T.activeToasts)
+            assert.equal(30000, T.activeToasts[1].lootData.copperAmount)
+        end)
+
+        it("stacks items: increments quantity", function()
+            T.ShowToast(makeItemData({ quantity = 2 }))
+            T.ShowToast(makeItemData({ quantity = 3 }))
+            assert.equal(1, #T.activeToasts)
+            assert.equal(5, T.activeToasts[1].lootData.quantity)
+        end)
+
+        it("early returns for queue duplicates", function()
+            ns.Addon.db.profile.display.maxToasts = 0
+            T.ShowToast(makeXPData({ xpAmount = 100 }))
+            assert.equal(0, #T.activeToasts) -- went to queue
+
+            T.ShowToast(makeXPData({ xpAmount = 200 }))
+            assert.equal(0, #T.activeToasts) -- merged in queue, no new toast
+
+            ns.Addon.db.profile.display.maxToasts = 5
+        end)
+
+        it("creates new toast when no duplicate found", function()
+            T.ShowToast(makeItemData({ itemID = 111 }))
+            T.ShowToast(makeItemData({ itemID = 222 }))
+            assert.equal(2, #T.activeToasts)
+        end)
+
+    end)
+
+    -- =================================================================
+    -- ShowToast - Overflow
+    -- =================================================================
+
+    describe("ShowToast - overflow", function()
+
+        it("pushes to toastQueue when at maxToasts", function()
+            ns.Addon.db.profile.display.maxToasts = 2
+            T.ShowToast(makeItemData({ itemID = 1 }))
+            T.ShowToast(makeItemData({ itemID = 2 }))
+            T.ShowToast(makeItemData({ itemID = 3 }))
+            assert.equal(2, #T.activeToasts)
+            assert.equal(1, T.QueueSize(T.toastQueue))
+
+            ns.Addon.db.profile.display.maxToasts = 5
+        end)
+
+        it("FlushQueue drains toastQueue up to maxToasts", function()
+            ns.Addon.db.profile.display.maxToasts = 1
+            T.ShowToast(makeItemData({ itemID = 1 }))
+            T.ShowToast(makeItemData({ itemID = 2 }))
+            assert.equal(1, #T.activeToasts)
+            assert.equal(1, T.QueueSize(T.toastQueue))
+
+            -- Simulate toast finishing (free up a slot)
+            ns.Addon.db.profile.display.maxToasts = 5
+            TM.FlushQueue()
+            assert.equal(2, #T.activeToasts)
+            assert.equal(0, T.QueueSize(T.toastQueue))
+
+            ns.Addon.db.profile.display.maxToasts = 5
+        end)
+
+    end)
+
+    -- =================================================================
+    -- QueueToast - Guards
+    -- =================================================================
+
+    describe("QueueToast - guards", function()
+
+        it("skips when addon disabled", function()
+            ns.Addon.db.profile.enabled = false
+            TM.QueueToast(makeItemData())
+            assert.equal(0, #T.activeToasts)
+            ns.Addon.db.profile.enabled = true
+        end)
+
+        it("defers to combatQueue during combat", function()
+            ns.Addon.db.profile.combat.deferInCombat = true
+            mock._inCombat = true
+            TM.QueueToast(makeItemData())
+            assert.equal(0, #T.activeToasts)
+            assert.equal(1, T.QueueSize(T.combatQueue))
+            ns.Addon.db.profile.combat.deferInCombat = false
+            mock._inCombat = false
+        end)
+
+        it("skips when suppressed for normal items", function()
+            mock._suppressed = true
+            TM.QueueToast(makeItemData())
+            assert.equal(0, #T.activeToasts)
+            mock._suppressed = false
+        end)
+
+        it("bypasses suppression for XP toasts", function()
+            mock._suppressed = true
+            TM.QueueToast(makeXPData())
+            assert.equal(1, #T.activeToasts)
+            mock._suppressed = false
+        end)
+
+        it("bypasses suppression for Honor toasts", function()
+            mock._suppressed = true
+            TM.QueueToast(makeHonorData())
+            assert.equal(1, #T.activeToasts)
+            mock._suppressed = false
+        end)
+
+        it("bypasses suppression for currency toasts", function()
+            mock._suppressed = true
+            TM.QueueToast(makeGoldData())
+            assert.equal(1, #T.activeToasts)
+            mock._suppressed = false
+        end)
+
+    end)
+
+    -- =================================================================
+    -- Integration - End-to-end stacking
+    -- =================================================================
+
+    describe("Integration - end-to-end stacking", function()
+
+        it("5 rapid XP events produce 1 toast with summed XP", function()
+            for i = 1, 5 do
+                TM.QueueToast(makeXPData({ xpAmount = 100 * i }))
+            end
+            assert.equal(1, #T.activeToasts)
+            -- 100 + 200 + 300 + 400 + 500 = 1500
+            assert.equal(1500, T.activeToasts[1].lootData.xpAmount)
+        end)
+
+        it("3 identical items produce 1 toast with quantity 3", function()
+            TM.QueueToast(makeItemData({ quantity = 1 }))
+            TM.QueueToast(makeItemData({ quantity = 1 }))
+            TM.QueueToast(makeItemData({ quantity = 1 }))
+            assert.equal(1, #T.activeToasts)
+            assert.equal(3, T.activeToasts[1].lootData.quantity)
+        end)
+
+        it("3 gold events produce 1 toast with summed copper", function()
+            TM.QueueToast(makeGoldData({ copperAmount = 10000 }))
+            TM.QueueToast(makeGoldData({ copperAmount = 20000 }))
+            TM.QueueToast(makeGoldData({ copperAmount = 30000 }))
+            assert.equal(1, #T.activeToasts)
+            assert.equal(60000, T.activeToasts[1].lootData.copperAmount)
+        end)
+
+        it("event after DUPLICATE_WINDOW creates separate toast", function()
+            TM.QueueToast(makeXPData({ xpAmount = 100 }))
+            assert.equal(1, #T.activeToasts)
+
+            mock.AdvanceTime(T.DUPLICATE_WINDOW + 0.1)
+            TM.QueueToast(makeXPData({ xpAmount = 200 }))
+            assert.equal(2, #T.activeToasts)
+        end)
+
+    end)
+
+end)

--- a/spec/wow_mock.lua
+++ b/spec/wow_mock.lua
@@ -1,0 +1,307 @@
+-------------------------------------------------------------------------------
+-- wow_mock.lua
+-- Lightweight WoW API mock for busted unit tests
+-------------------------------------------------------------------------------
+
+local M = {}
+
+-------------------------------------------------------------------------------
+-- Mock time (controllable clock)
+-------------------------------------------------------------------------------
+
+local mockTime = 0
+
+function M.SetTime(t)
+    mockTime = t
+end
+
+function M.AdvanceTime(dt)
+    mockTime = mockTime + dt
+end
+
+-- luacheck: push ignore 121 122
+
+-------------------------------------------------------------------------------
+-- Core WoW API mocks
+-------------------------------------------------------------------------------
+
+function GetTime()
+    return mockTime
+end
+
+function InCombatLockdown()
+    return M._inCombat or false
+end
+
+function PlaySoundFile() end
+
+function UnitName()
+    return "TestPlayer"
+end
+
+function GetCoinTextureString(copper)
+    return tostring(copper) .. "c"
+end
+
+-------------------------------------------------------------------------------
+-- Frame mock
+-------------------------------------------------------------------------------
+
+local function CreateMockFrame()
+    local frame = {
+        _points = {},
+        _shown = false,
+        _size = { w = 0, h = 0 },
+        _scripts = {},
+        lootData = nil,
+    }
+
+    function frame:SetPoint(point, relativeTo, relativePoint, x, y)
+        self._points = { point = point, relativeTo = relativeTo, relativePoint = relativePoint, x = x, y = y }
+    end
+
+    function frame:ClearAllPoints()
+        self._points = {}
+    end
+
+    function frame:GetPoint()
+        local p = self._points
+        return p.point, p.relativeTo, p.relativePoint, p.x or 0, p.y or 0
+    end
+
+    function frame:Show()
+        self._shown = true
+    end
+
+    function frame:Hide()
+        self._shown = false
+    end
+
+    function frame:IsShown()
+        return self._shown
+    end
+
+    function frame:SetSize(w, h)
+        self._size = { w = w, h = h }
+    end
+
+    function frame:GetWidth()
+        return self._size.w
+    end
+
+    function frame:GetHeight()
+        return self._size.h
+    end
+
+    function frame:SetMovable() end
+    function frame:SetClampedToScreen() end
+    function frame:EnableMouse() end
+    function frame:StartMoving() end
+    function frame:StopMovingOrSizing() end
+
+    function frame:CreateTexture()
+        return {
+            SetAllPoints = function() end,
+            SetColorTexture = function() end,
+        }
+    end
+
+    function frame:CreateFontString()
+        return {
+            SetPoint = function() end,
+            SetText = function() end,
+        }
+    end
+
+    function frame:SetScript(event, handler)
+        self._scripts[event] = handler
+    end
+
+    return frame
+end
+
+function CreateFrame()
+    return CreateMockFrame()
+end
+
+UIParent = CreateMockFrame()
+
+-------------------------------------------------------------------------------
+-- LibStub mock
+-------------------------------------------------------------------------------
+
+function LibStub()
+    return {
+        Fetch = function() return nil end,
+    }
+end
+
+-------------------------------------------------------------------------------
+-- Lua globals WoW adds
+-------------------------------------------------------------------------------
+
+function wipe(t)
+    for k in pairs(t) do
+        t[k] = nil
+    end
+    return t
+end
+
+-- luacheck: pop
+
+-------------------------------------------------------------------------------
+-- Namespace builder
+-------------------------------------------------------------------------------
+
+function M.CreateNamespace()
+    local ns = {}
+
+    -- Color constants
+    ns.COLOR_GOLD = "|cffffd700"
+    ns.COLOR_GREEN = "|cff00ff00"
+    ns.COLOR_RED = "|cffff0000"
+    ns.COLOR_GRAY = "|cff888888"
+    ns.COLOR_WHITE = "|cffffffff"
+    ns.COLOR_RESET = "|r"
+
+    -- Utility functions
+    function ns.Print() end
+    function ns.DebugPrint() end
+    function ns.FormatNumber(num)
+        if num >= 1000000 then
+            return string.format("%.1fM", num / 1000000)
+        elseif num >= 1000 then
+            return string.format("%.1fK", num / 1000)
+        end
+        return tostring(num)
+    end
+
+    -- Initialize sub-tables
+    ns.ToastManager = {}
+
+    -- Mock ToastFrame
+    ns.ToastFrame = {
+        Acquire = function()
+            return CreateMockFrame()
+        end,
+        Populate = function(frame, lootData)
+            frame.lootData = lootData
+        end,
+        Release = function(frame)
+            frame.lootData = nil
+        end,
+    }
+
+    -- Mock ToastAnimations
+    ns.ToastAnimations = {
+        PlayLifecycle = function() end,
+        UpdateLifecycle = function() end,
+        PlaySlide = function() end,
+        StopAll = function() end,
+        Dismiss = function() end,
+    }
+
+    -- Mock MessageBridge
+    ns.MessageBridge = {
+        IsSuppressed = function() return M._suppressed or false end,
+    }
+
+    -- Mock HonorListener
+    ns.HonorListener = {
+        GetHonorIcon = function() return 463450 end,
+    }
+
+    -- Mock Addon (Ace3 mixin)
+    ns.Addon = {
+        db = {
+            profile = {
+                enabled = true,
+                display = {
+                    maxToasts = 5,
+                    toastWidth = 300,
+                    toastHeight = 40,
+                    growDirection = "UP",
+                    anchorPoint = "RIGHT",
+                    anchorX = -20,
+                    anchorY = 0,
+                    spacing = 4,
+                    showQuantity = true,
+                },
+                filters = {
+                    minQuality = 0,
+                    showSelfLoot = true,
+                    showGroupLoot = true,
+                    showCurrency = true,
+                    showGold = true,
+                    showQuestItems = true,
+                    showXP = true,
+                },
+                combat = {
+                    deferInCombat = false,
+                },
+                sound = {
+                    enabled = false,
+                    soundFile = "None",
+                },
+                animation = {
+                    enableAnimations = true,
+                    holdDuration = 4,
+                },
+                appearance = {
+                    iconSize = 32,
+                },
+                elvui = {
+                    useSkin = false,
+                },
+                minimap = {
+                    hide = false,
+                },
+            },
+        },
+        ScheduleRepeatingTimer = function() return {} end,
+        ScheduleTimer = function(self, func, _delay)
+            -- In tests, execute immediately (no real timer)
+            if func then func() end
+            return {}
+        end,
+        CancelTimer = function() end,
+        RegisterEvent = function() end,
+    }
+
+    return ns
+end
+
+-------------------------------------------------------------------------------
+-- Module loader
+-------------------------------------------------------------------------------
+
+function M.LoadToastManager(ns)
+    local path = "Display/ToastManager.lua"
+    local chunk, err = loadfile(path)
+    if not chunk then
+        error("Failed to load " .. path .. ": " .. (err or "unknown error"))
+    end
+    -- Call with the addon name and namespace as varargs
+    chunk("DragonToast", ns)
+    return ns.ToastManager
+end
+
+-------------------------------------------------------------------------------
+-- Reset helpers
+-------------------------------------------------------------------------------
+
+function M.Reset(ns)
+    mockTime = 0
+    M._inCombat = false
+    M._suppressed = false
+
+    -- Clear active toasts
+    local t = ns.ToastManager._test
+    if t then
+        wipe(t.activeToasts)
+        t.QueueReset(t.toastQueue)
+        t.QueueReset(t.combatQueue)
+    end
+end
+
+return M


### PR DESCRIPTION
## Summary

Fixes stacking/accumulation bugs and introduces a full unit test infrastructure.

### Bug Fixes
- **Gold not stacking**: `FindDuplicate` excluded currency items that use `copperAmount`, so consecutive gold pickups never stacked. Fixed by allowing currency duplicates to match on `copperAmount`.
- **Test mode not showing stacking**: The test interval (2.5s) exceeded the duplicate detection window, and each test toast had a unique ID, preventing stacking. Fixed both the timing and ID generation.

### New Features
- **Stack test commands**: `/dt test stack|xp|gold|honor|all` for targeted in-game stack testing via `RunStackTest()`
- **`_test` exposure table** on `ToastManager` for busted unit testing (only exposes internals, no production impact)

### Test Infrastructure
- **39 busted unit tests** covering `ToastManager` queue, stacking, dequeue, combat deferral, suppression, and edge cases (`spec/ToastManager_spec.lua`)
- **WoW API mock layer** (`spec/wow_mock.lua`) providing lightweight stubs for Ace3, LibStub, and core WoW globals
- **`_run_tests.ps1`** for running busted on Windows
- **CI workflow** updated with a busted test job alongside existing luacheck

### Config / Tooling
- `.luacheckrc` updated with `spec/` file overrides
- `.busted` config file added