### PR TITLE
refactor: extract shared listener helpers into ListenerUtils

### DIFF
--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -39,6 +39,7 @@ ns.QUALITY_COLORS = {
 -- Namespace sub-tables (populated by other files)
 -------------------------------------------------------------------------------
 
+ns.ListenerUtils = {}
 ns.ToastManager = {}
 ns.ToastFrame = {}
 ns.ToastAnimations = {}

--- a/Core/ListenerUtils.lua
+++ b/Core/ListenerUtils.lua
@@ -1,0 +1,124 @@
+-------------------------------------------------------------------------------
+-- ListenerUtils.lua
+-- Shared utility functions and constants used across listener modules
+--
+-- Supported versions: TBC Anniversary, Retail, MoP Classic
+-------------------------------------------------------------------------------
+
+local _, ns = ...
+local Utils = ns.ListenerUtils
+
+-- Cache Lua globals
+local tonumber = tonumber
+local math_floor = math.floor
+local string_format = string.format
+local table_concat = table.concat
+
+-------------------------------------------------------------------------------
+-- Constants
+-------------------------------------------------------------------------------
+
+Utils.GOLD_ICON = 133784
+Utils.QUESTION_MARK_ICON = 134400
+Utils.MAX_RETRIES = 5
+Utils.RETRY_INTERVAL = 0.2
+
+-------------------------------------------------------------------------------
+-- BuildPattern(globalString, anchor)
+-- Converts a WoW GlobalString (with %s/%d placeholders) into a Lua pattern.
+-- When anchor is true, wraps in ^ and $ and returns nil for nil input.
+-------------------------------------------------------------------------------
+
+function Utils.BuildPattern(globalString, anchor)
+    if anchor and not globalString then return nil end
+    local pattern = globalString:gsub("([%(%)%.%%%+%-%*%?%[%]%^%$])", "%%%1")
+    pattern = pattern:gsub("%%%%s", "(.+)")
+    pattern = pattern:gsub("%%%%d", "(%%d+)")
+    if anchor then
+        return "^" .. pattern .. "$"
+    end
+    return pattern
+end
+
+-------------------------------------------------------------------------------
+-- ParseMoneyString(moneyString)
+-- Parses a localized money string into total copper value.
+-- Tries text-based patterns first, then texture-based fallbacks.
+-------------------------------------------------------------------------------
+
+local PATTERN_GOLD = Utils.BuildPattern(GOLD_AMOUNT)
+local PATTERN_SILVER = Utils.BuildPattern(SILVER_AMOUNT)
+local PATTERN_COPPER = Utils.BuildPattern(COPPER_AMOUNT)
+local PATTERN_GOLD_TEXTURE = Utils.BuildPattern(GOLD_AMOUNT_TEXTURE)
+local PATTERN_SILVER_TEXTURE = Utils.BuildPattern(SILVER_AMOUNT_TEXTURE)
+local PATTERN_COPPER_TEXTURE = Utils.BuildPattern(COPPER_AMOUNT_TEXTURE)
+
+function Utils.ParseMoneyString(moneyString)
+    local gold, silver, copper = 0, 0, 0
+
+    -- Try text-based patterns first
+    local g = moneyString:match(PATTERN_GOLD)
+    if g then gold = tonumber(g) or 0 end
+
+    local s = moneyString:match(PATTERN_SILVER)
+    if s then silver = tonumber(s) or 0 end
+
+    local c = moneyString:match(PATTERN_COPPER)
+    if c then copper = tonumber(c) or 0 end
+
+    -- Fall back to texture-based patterns if text patterns found nothing
+    if gold == 0 and silver == 0 and copper == 0 then
+        g = moneyString:match(PATTERN_GOLD_TEXTURE)
+        if g then gold = tonumber(g) or 0 end
+
+        s = moneyString:match(PATTERN_SILVER_TEXTURE)
+        if s then silver = tonumber(s) or 0 end
+
+        c = moneyString:match(PATTERN_COPPER_TEXTURE)
+        if c then copper = tonumber(c) or 0 end
+    end
+
+    local total = gold * 10000 + silver * 100 + copper
+    return total > 0 and total or nil
+end
+
+-------------------------------------------------------------------------------
+-- FormatGold(copper)
+-- Formats a copper amount into a display string with gold/silver/copper parts.
+-------------------------------------------------------------------------------
+
+function Utils.FormatGold(copper)
+    local gold = math_floor(copper / 10000)
+    local silver = math_floor((copper % 10000) / 100)
+    local copperRemainder = copper % 100
+    local parts = {}
+    if gold > 0 then parts[#parts + 1] = gold .. "g" end
+    if silver > 0 then parts[#parts + 1] = silver .. "s" end
+    if copperRemainder > 0 then parts[#parts + 1] = copperRemainder .. "c" end
+    if #parts == 0 then parts[#parts + 1] = "0c" end
+    return string_format("|T%d:0:0:0:0|t%s", Utils.GOLD_ICON, table_concat(parts, " "))
+end
+
+-------------------------------------------------------------------------------
+-- RetryWithTimer(addon, buildFunc, filterFunc, retries)
+-- Retries a build function up to MAX_RETRIES times at RETRY_INTERVAL seconds.
+-- If buildFunc() returns data and filterFunc(data) passes, queues the toast.
+-------------------------------------------------------------------------------
+
+function Utils.RetryWithTimer(addon, buildFunc, filterFunc, retries)
+    retries = retries or 0
+    if retries >= Utils.MAX_RETRIES then
+        ns.DebugPrint("Max retries reached, giving up")
+        return
+    end
+    local data = buildFunc()
+    if data then
+        if filterFunc(data) then
+            ns.ToastManager.QueueToast(data)
+        end
+    else
+        addon:ScheduleTimer(function()
+            Utils.RetryWithTimer(addon, buildFunc, filterFunc, retries + 1)
+        end, Utils.RETRY_INTERVAL)
+    end
+end

--- a/DragonToast.toc
+++ b/DragonToast.toc
@@ -17,6 +17,7 @@ Libs\embeds.xml
 
 # Core (shared)
 Core\Init.lua
+Core\ListenerUtils.lua
 Core\Presets.lua
 Core\Config.lua
 Core\ConfigWindow.lua

--- a/Listeners/HonorListener_Retail.lua
+++ b/Listeners/HonorListener_Retail.lua
@@ -6,6 +6,7 @@
 -------------------------------------------------------------------------------
 
 local ADDON_NAME, ns = ...
+local Utils = ns.ListenerUtils
 
 local WOW_PROJECT_ID = WOW_PROJECT_ID
 local WOW_PROJECT_MAINLINE = WOW_PROJECT_MAINLINE
@@ -45,19 +46,8 @@ end
 
 -------------------------------------------------------------------------------
 -- Pattern Building
--- WoW global strings use %s for strings and %d for numbers.
--- We convert them to Lua patterns for matching.
+-- Uses shared BuildPattern with anchor=true for honor patterns.
 -------------------------------------------------------------------------------
-
-local function BuildPattern(globalString)
-    if not globalString then return nil end
-    -- Escape magic pattern characters
-    local pattern = globalString:gsub("([%(%)%.%%%+%-%*%?%[%]%^%$])", "%%%1")
-    -- Replace %d with number capture, %s with string capture
-    pattern = pattern:gsub("%%%%d", "(%%d+)")
-    pattern = pattern:gsub("%%%%s", "(.+)")
-    return "^" .. pattern .. "$"
-end
 
 -- Build patterns from WoW global strings (available in both TBC and Retail)
 -- These globals are set by Blizzard's localization system
@@ -66,12 +56,12 @@ local PATTERNS = {}
 local function InitPatterns()
     -- "%s dies, honorable kill Rank: %s (Estimated Honor Points: %d)"
     if COMBATLOG_HONORGAIN then
-        PATTERNS.honorGain = BuildPattern(COMBATLOG_HONORGAIN)
+        PATTERNS.honorGain = Utils.BuildPattern(COMBATLOG_HONORGAIN, true)
     end
 
     -- "You have been awarded %d honor points."
     if COMBATLOG_HONORAWARD then
-        PATTERNS.honorAward = BuildPattern(COMBATLOG_HONORAWARD)
+        PATTERNS.honorAward = Utils.BuildPattern(COMBATLOG_HONORAWARD, true)
     end
 end
 

--- a/Listeners/HonorListener_TBC.lua
+++ b/Listeners/HonorListener_TBC.lua
@@ -6,6 +6,7 @@
 -------------------------------------------------------------------------------
 
 local ADDON_NAME, ns = ...
+local Utils = ns.ListenerUtils
 
 local WOW_PROJECT_ID = WOW_PROJECT_ID
 local WOW_PROJECT_BURNING_CRUSADE_CLASSIC = WOW_PROJECT_BURNING_CRUSADE_CLASSIC
@@ -44,19 +45,8 @@ end
 
 -------------------------------------------------------------------------------
 -- Pattern Building
--- WoW global strings use %s for strings and %d for numbers.
--- We convert them to Lua patterns for matching.
+-- Uses shared BuildPattern with anchor=true for honor patterns.
 -------------------------------------------------------------------------------
-
-local function BuildPattern(globalString)
-    if not globalString then return nil end
-    -- Escape magic pattern characters
-    local pattern = globalString:gsub("([%(%)%.%%%+%-%*%?%[%]%^%$])", "%%%1")
-    -- Replace %d with number capture, %s with string capture
-    pattern = pattern:gsub("%%%%d", "(%%d+)")
-    pattern = pattern:gsub("%%%%s", "(.+)")
-    return "^" .. pattern .. "$"
-end
 
 -- Build patterns from WoW global strings (available in both TBC and Retail)
 -- These globals are set by Blizzard's localization system
@@ -65,12 +55,12 @@ local PATTERNS = {}
 local function InitPatterns()
     -- "%s dies, honorable kill Rank: %s (Estimated Honor Points: %d)"
     if COMBATLOG_HONORGAIN then
-        PATTERNS.honorGain = BuildPattern(COMBATLOG_HONORGAIN)
+        PATTERNS.honorGain = Utils.BuildPattern(COMBATLOG_HONORGAIN, true)
     end
 
     -- "You have been awarded %d honor points."
     if COMBATLOG_HONORAWARD then
-        PATTERNS.honorAward = BuildPattern(COMBATLOG_HONORAWARD)
+        PATTERNS.honorAward = Utils.BuildPattern(COMBATLOG_HONORAWARD, true)
     end
 end
 

--- a/Listeners/MailListener_TBC.lua
+++ b/Listeners/MailListener_TBC.lua
@@ -6,6 +6,7 @@
 -------------------------------------------------------------------------------
 
 local ADDON_NAME, ns = ...
+local Utils = ns.ListenerUtils
 
 -------------------------------------------------------------------------------
 -- Version guard: only run on TBC Anniversary
@@ -40,8 +41,6 @@ ns.MailListener = ns.MailListener or {}
 -- Constants
 -------------------------------------------------------------------------------
 
-local MAX_RETRIES = 5
-local GOLD_ICON = 133784
 local ATTACHMENTS_MAX = 12 -- ATTACHMENTS_MAX_RECEIVE in Blizzard code
 
 -------------------------------------------------------------------------------
@@ -169,7 +168,7 @@ local function BuildMailItemData(snapshot)
         itemLevel = itemLevel or 0,
         itemType = snapshot.sourceLabel,
         itemSubType = itemSubType or "",
-        itemIcon = itemTexture or 134400,
+        itemIcon = itemTexture or Utils.QUESTION_MARK_ICON,
         quantity = snapshot.count,
         looter = UnitName("player"),
         isSelf = true,
@@ -192,7 +191,7 @@ local function BuildMailMoneyData(snapshot)
         itemLevel = 0,
         itemType = snapshot.sourceLabel,
         itemSubType = "Gold",
-        itemIcon = GOLD_ICON,
+        itemIcon = Utils.GOLD_ICON,
         quantity = 1,
         copperAmount = snapshot.copperAmount,
         looter = UnitName("player"),
@@ -201,30 +200,6 @@ local function BuildMailMoneyData(snapshot)
         isMail = true,
         timestamp = GetTime(),
     }
-end
-
--------------------------------------------------------------------------------
--- Retry pattern for item cache misses
--------------------------------------------------------------------------------
-
-local function RetryBuildMailItem(snapshot, retries)
-    retries = retries or 0
-    if retries >= MAX_RETRIES then
-        ns.DebugPrint("MailListener: failed to get item info for ID "
-            .. tostring(snapshot.itemID) .. " after " .. MAX_RETRIES .. " retries")
-        return
-    end
-
-    local lootData = BuildMailItemData(snapshot)
-    if lootData then
-        if PassesFilter(lootData) then
-            ns.ToastManager.QueueToast(lootData)
-        end
-    else
-        ns.Addon:ScheduleTimer(function()
-            RetryBuildMailItem(snapshot, retries + 1)
-        end, 0.2)
-    end
 end
 
 -------------------------------------------------------------------------------
@@ -240,7 +215,11 @@ local function ProcessSnapshot(snapshot)
             ns.ToastManager.QueueToast(lootData)
         end
     elseif snapshot.type == "item" then
-        RetryBuildMailItem(snapshot)
+        Utils.RetryWithTimer(
+            ns.Addon,
+            function() return BuildMailItemData(snapshot) end,
+            PassesFilter
+        )
     end
 end
 

--- a/Listeners/XPListener.lua
+++ b/Listeners/XPListener.lua
@@ -6,6 +6,7 @@
 -------------------------------------------------------------------------------
 
 local ADDON_NAME, ns = ...
+local Utils = ns.ListenerUtils
 
 -------------------------------------------------------------------------------
 -- Cached WoW API
@@ -24,23 +25,12 @@ local string_match = string.match
 -- XP icon (a generic XP/level-up style icon)
 local XP_ICON = 894556   -- Interface\Icons\UI_Chat (chat bubble icon, common for XP)
 -- XP quality color (gold/amber)
-local XP_QUALITY = 1  -- Common quality (white) — we override color in ToastFrame
+local XP_QUALITY = 1  -- Common quality (white) -- we override color in ToastFrame
 
 -------------------------------------------------------------------------------
 -- Pattern Building
--- WoW global strings use %s for strings and %d for numbers.
--- We convert them to Lua patterns for matching.
+-- Uses shared BuildPattern with anchor=true for XP patterns.
 -------------------------------------------------------------------------------
-
-local function BuildPattern(globalString)
-    if not globalString then return nil end
-    -- Escape magic pattern characters
-    local pattern = globalString:gsub("([%(%)%.%%%+%-%*%?%[%]%^%$])", "%%%1")
-    -- Replace %d with number capture, %s with string capture
-    pattern = pattern:gsub("%%%%d", "(%%d+)")
-    pattern = pattern:gsub("%%%%s", "(.+)")
-    return "^" .. pattern .. "$"
-end
 
 -- Build patterns from WoW global strings (available in both TBC and Retail)
 -- These globals are set by Blizzard's localization system
@@ -49,38 +39,38 @@ local PATTERNS = {}
 local function InitPatterns()
     -- "You gain %d experience." (no mob)
     if COMBATLOG_XPGAIN_FIRSTPERSON_UNNAMED then
-        PATTERNS.unnamed = BuildPattern(COMBATLOG_XPGAIN_FIRSTPERSON_UNNAMED)
+        PATTERNS.unnamed = Utils.BuildPattern(COMBATLOG_XPGAIN_FIRSTPERSON_UNNAMED, true)
     end
 
     -- "%s dies, you gain %d experience." (with mob)
     if COMBATLOG_XPGAIN_FIRSTPERSON then
-        PATTERNS.named = BuildPattern(COMBATLOG_XPGAIN_FIRSTPERSON)
+        PATTERNS.named = Utils.BuildPattern(COMBATLOG_XPGAIN_FIRSTPERSON, true)
     end
 
     -- Rested bonus variants: "%s dies, you gain %d experience. (%s exp %s bonus)"
     if COMBATLOG_XPGAIN_EXHAUSTION1 then
-        PATTERNS.rested1 = BuildPattern(COMBATLOG_XPGAIN_EXHAUSTION1)
+        PATTERNS.rested1 = Utils.BuildPattern(COMBATLOG_XPGAIN_EXHAUSTION1, true)
     end
     if COMBATLOG_XPGAIN_EXHAUSTION2 then
-        PATTERNS.rested2 = BuildPattern(COMBATLOG_XPGAIN_EXHAUSTION2)
+        PATTERNS.rested2 = Utils.BuildPattern(COMBATLOG_XPGAIN_EXHAUSTION2, true)
     end
 
     -- Rested unnamed: "You gain %d experience. (%s exp %s bonus)"
     if COMBATLOG_XPGAIN_EXHAUSTION1_UNNAMED then
-        PATTERNS.restedUnnamed1 = BuildPattern(COMBATLOG_XPGAIN_EXHAUSTION1_UNNAMED)
+        PATTERNS.restedUnnamed1 = Utils.BuildPattern(COMBATLOG_XPGAIN_EXHAUSTION1_UNNAMED, true)
     end
     if COMBATLOG_XPGAIN_EXHAUSTION2_UNNAMED then
-        PATTERNS.restedUnnamed2 = BuildPattern(COMBATLOG_XPGAIN_EXHAUSTION2_UNNAMED)
+        PATTERNS.restedUnnamed2 = Utils.BuildPattern(COMBATLOG_XPGAIN_EXHAUSTION2_UNNAMED, true)
     end
 
     -- Guild bonus: "%s dies, you gain %d experience. (+%d exp Guild Bonus)"
     if COMBATLOG_XPGAIN_FIRSTPERSON_GUILD then
-        PATTERNS.guild = BuildPattern(COMBATLOG_XPGAIN_FIRSTPERSON_GUILD)
+        PATTERNS.guild = Utils.BuildPattern(COMBATLOG_XPGAIN_FIRSTPERSON_GUILD, true)
     end
 
     -- Unnamed guild bonus: "You gain %d experience. (+%d exp Guild Bonus)"
     if COMBATLOG_XPGAIN_FIRSTPERSON_UNNAMED_GUILD then
-        PATTERNS.guildUnnamed = BuildPattern(COMBATLOG_XPGAIN_FIRSTPERSON_UNNAMED_GUILD)
+        PATTERNS.guildUnnamed = Utils.BuildPattern(COMBATLOG_XPGAIN_FIRSTPERSON_UNNAMED_GUILD, true)
     end
 
     -- Quest XP: "You gain %d experience." (same as unnamed, quest context handled by event)


### PR DESCRIPTION
## Summary
- Extracts duplicated helper functions (`BuildPattern`, `ParseMoneyString`, retry logic) and shared constants (`GOLD_ICON`, `QUESTION_MARK_ICON`, `MAX_RETRIES`) from 7 listener files into a single `Core/ListenerUtils.lua` utility module
- Refactors all listener files to use `ns.ListenerUtils` instead of local duplicates, reducing code by ~85 lines net

## Changes
- **New file**: `Core/ListenerUtils.lua` - shared `BuildPattern()`, `ParseMoneyString()`, `FormatGold()`, `RetryWithTimer()`, and icon/retry constants
- **Updated**: `Core/Init.lua` - added `ns.ListenerUtils` sub-table
- **Updated**: `DragonToast.toc` - added `Core\ListenerUtils.lua` load entry after `Init.lua`
- **Refactored**: `LootListener_Retail.lua`, `LootListener_TBC.lua` - removed local `BuildPattern`, `ParseMoneyString`, `RetryBuildLootData`, `MAX_RETRIES`; uses `Utils.*` equivalents
- **Refactored**: `MailListener_Retail.lua`, `MailListener_TBC.lua` - removed local `MAX_RETRIES`, `GOLD_ICON`, `RetryBuildMailItem`; uses `Utils.*` equivalents
- **Refactored**: `HonorListener_Retail.lua`, `HonorListener_TBC.lua` - removed local `BuildPattern`; uses `Utils.BuildPattern(str, true)` for anchored patterns
- **Refactored**: `XPListener.lua` - removed local `BuildPattern`; uses `Utils.BuildPattern(str, true)` for anchored patterns

## Motivation
Several listener files contained identical helper logic duplicated across 2-4 files each. This increases maintenance burden and risks inconsistency when fixing bugs or updating patterns. Extracting to a shared module provides a single source of truth.

Closes #96

## Testing
- [x] luacheck passes with 0 warnings
- [ ] Manual: `/dt test` renders all toast types correctly
- [ ] Manual: `/dt testmode` continuous test mode works
- [ ] Manual: Loot, mail, honor, XP, and currency toasts fire correctly in-game

## Type of Change
- [x] Refactor (no functional changes)