### PR TITLE
feat: add reputation gain toasts (#93)

### DIFF
--- a/Core/Config.lua
+++ b/Core/Config.lua
@@ -25,6 +25,7 @@ local defaults = {
             showQuestItems = true,
             showXP = true,
             showHonor = true,
+            showReputation = true,
             showMail = true,
         },
 
@@ -106,7 +107,7 @@ local defaults = {
 -- Profile Migration
 -------------------------------------------------------------------------------
 
-local CURRENT_SCHEMA = 5
+local CURRENT_SCHEMA = 6
 
 local DIRECTION_TO_ANIMATION = {
     RIGHT  = "slideInRight",
@@ -187,6 +188,15 @@ local function MigrateProfile(db)
         -- v4 -> v5: mail filter default
         if profile.filters and profile.filters.showMail == nil then
             profile.filters.showMail = true
+        end
+
+        profile.schemaVersion = 5
+    end
+
+    if (profile.schemaVersion or 0) < 6 then
+        -- v5 -> v6: reputation filter default
+        if profile.filters and profile.filters.showReputation == nil then
+            profile.filters.showReputation = true
         end
 
         profile.schemaVersion = CURRENT_SCHEMA

--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -47,6 +47,7 @@ ns.ElvUISkin = {}
 ns.LootListener = {}
 ns.XPListener = {}
 ns.HonorListener = {}
+ns.ReputationListener = {}
 ns.CurrencyListener = {}
 ns.MessageBridge = {}
 ns.MailListener = {}
@@ -146,6 +147,11 @@ function Addon:OnEnable()
         ns.HonorListener.Initialize(self)
     end
 
+    -- Initialize reputation listener
+    if ns.ReputationListener.Initialize then
+        ns.ReputationListener.Initialize(self)
+    end
+
     -- Initialize Currency listener
     if ns.CurrencyListener.Initialize then
         ns.CurrencyListener.Initialize(self)
@@ -176,6 +182,11 @@ function Addon:OnDisable()
     -- Shutdown Honor listener
     if ns.HonorListener.Shutdown then
         ns.HonorListener.Shutdown()
+    end
+
+    -- Shutdown reputation listener
+    if ns.ReputationListener.Shutdown then
+        ns.ReputationListener.Shutdown()
     end
 
     -- Shutdown Currency listener

--- a/Core/ListenerUtils.lua
+++ b/Core/ListenerUtils.lua
@@ -9,10 +9,48 @@ local _, ns = ...
 local Utils = ns.ListenerUtils
 
 -- Cache Lua globals
+local tostring = tostring
 local tonumber = tonumber
 local math_floor = math.floor
 local string_format = string.format
 local table_concat = table.concat
+
+local function BuildLocalizedPattern(globalString, anchor)
+    if not globalString then return nil, nil end
+
+    local pattern = tostring(globalString)
+    local captureOrder = {}
+    local literalPercentToken = "\1LITERAL_PERCENT\2"
+    local stringToken = "\1STRING_CAPTURE\2"
+    local numberToken = "\1NUMBER_CAPTURE\2"
+
+    pattern = pattern:gsub("%%%%", literalPercentToken)
+    pattern = pattern:gsub("%%(%d+)%$([sd])", function(index, placeholderType)
+        captureOrder[#captureOrder + 1] = tonumber(index)
+        if placeholderType == "s" then
+            return stringToken
+        end
+        return numberToken
+    end)
+    pattern = pattern:gsub("%%([sd])", function(placeholderType)
+        captureOrder[#captureOrder + 1] = #captureOrder + 1
+        if placeholderType == "s" then
+            return stringToken
+        end
+        return numberToken
+    end)
+
+    pattern = pattern:gsub("([%(%)%.%%%+%-%*%?%[%]%^%$])", "%%%1")
+    pattern = pattern:gsub(stringToken, "(.+)")
+    pattern = pattern:gsub(numberToken, "(%%d+)")
+    pattern = pattern:gsub(literalPercentToken, "%%%%")
+
+    if anchor then
+        pattern = "^" .. pattern .. "$"
+    end
+
+    return pattern, captureOrder
+end
 
 -------------------------------------------------------------------------------
 -- Constants
@@ -30,14 +68,18 @@ Utils.RETRY_INTERVAL = 0.2
 -------------------------------------------------------------------------------
 
 function Utils.BuildPattern(globalString, anchor)
-    if anchor and not globalString then return nil end
-    local pattern = globalString:gsub("([%(%)%.%%%+%-%*%?%[%]%^%$])", "%%%1")
-    pattern = pattern:gsub("%%%%s", "(.+)")
-    pattern = pattern:gsub("%%%%d", "(%%d+)")
-    if anchor then
-        return "^" .. pattern .. "$"
-    end
+    local pattern = BuildLocalizedPattern(globalString, anchor)
     return pattern
+end
+
+-------------------------------------------------------------------------------
+-- BuildCapturePattern(globalString, anchor)
+-- Like BuildPattern, but also returns placeholder order for localized positional
+-- format strings such as %2$s.
+-------------------------------------------------------------------------------
+
+function Utils.BuildCapturePattern(globalString, anchor)
+    return BuildLocalizedPattern(globalString, anchor)
 end
 
 -------------------------------------------------------------------------------

--- a/Core/SlashCommands.lua
+++ b/Core/SlashCommands.lua
@@ -12,6 +12,8 @@ local ADDON_NAME, ns = ...
 -------------------------------------------------------------------------------
 
 local print = print
+local string_lower = string.lower
+local string_match = string.match
 
 -------------------------------------------------------------------------------
 -- Quality names for status display
@@ -42,6 +44,7 @@ local function PrintStatus()
     print("  Gold: " .. (db.filters.showGold and "Yes" or "No"))
     print("  Quest Items: " .. (db.filters.showQuestItems and "Yes" or "No"))
     print("  XP Gains: " .. (db.filters.showXP and "Yes" or "No"))
+    print("  Reputation Gains: " .. (db.filters.showReputation and "Yes" or "No"))
     print("  Max Toasts: " .. db.display.maxToasts)
     print("  Growth: " .. db.display.growDirection)
     print("  Animations: " .. (db.animation.enableAnimations and "Yes" or "No"))
@@ -71,6 +74,7 @@ local function PrintHelp()
     print("  " .. ns.COLOR_WHITE .. "/dt test xp" .. ns.COLOR_RESET .. " -- Test XP accumulation")
     print("  " .. ns.COLOR_WHITE .. "/dt test gold" .. ns.COLOR_RESET .. " -- Test gold accumulation")
     print("  " .. ns.COLOR_WHITE .. "/dt test honor" .. ns.COLOR_RESET .. " -- Test honor accumulation")
+    print("  " .. ns.COLOR_WHITE .. "/dt test reputation" .. ns.COLOR_RESET .. " -- Test reputation accumulation")
     print("  " .. ns.COLOR_WHITE .. "/dt test all" .. ns.COLOR_RESET .. " -- Run all stacking tests")
     print("  " .. ns.COLOR_WHITE .. "/dt testmode" .. ns.COLOR_RESET .. " — Toggle continuous test toast generation")
     print("  " .. ns.COLOR_WHITE .. "/dt clear" .. ns.COLOR_RESET .. " — Dismiss all toasts")
@@ -83,8 +87,13 @@ end
 -- Command Router
 -------------------------------------------------------------------------------
 
+local function NormalizeCommand(input)
+    local trimmedInput = string_match(input or "", "^%s*(.-)%s*$")
+    return string_lower(trimmedInput)
+end
+
 function ns.HandleSlashCommand(input)
-    local cmd = (input or ""):lower():trim()
+    local cmd = NormalizeCommand(input)
 
     if cmd == "" then
         -- Toggle addon

--- a/Display/ToastFrame.lua
+++ b/Display/ToastFrame.lua
@@ -28,6 +28,14 @@ local LSM = LibStub("LibSharedMedia-3.0")
 local framePool = {}
 local frameCount = 0
 
+local function IsLinkableToast(lootData)
+    return lootData
+        and lootData.itemLink
+        and not lootData.isXP
+        and not lootData.isHonor
+        and not lootData.isReputation
+end
+
 --- Build a cache key for backdrop params to skip redundant SetBackdrop calls during stacking
 local function GetBackdropKey(bgFile)
     return bgFile or ""
@@ -285,8 +293,7 @@ local function CreateToastFrame()
     frame:RegisterForClicks("LeftButtonUp")
 
     frame:SetScript("OnClick", function(self)
-        if IsShiftKeyDown() and self.lootData and self.lootData.itemLink
-            and not self.lootData.isXP and not self.lootData.isHonor then
+        if IsShiftKeyDown() and IsLinkableToast(self.lootData) then
             ChatFrame_OpenChat(self.lootData.itemLink)
         else
             if ns.ToastManager.DismissToast then
@@ -296,7 +303,7 @@ local function CreateToastFrame()
     end)
 
     frame:SetScript("OnEnter", function(self)
-        if self.lootData and self.lootData.itemLink and not self.lootData.isXP and not self.lootData.isHonor then
+        if IsLinkableToast(self.lootData) then
             GameTooltip:SetOwner(self, "ANCHOR_LEFT")
             GameTooltip:SetHyperlink(self.lootData.itemLink)
             GameTooltip:Show()
@@ -363,6 +370,8 @@ local function PopulateToast(frame, lootData)
         r, g, b = 1, 0.82, 0
     elseif lootData.isHonor then
         r, g, b = 1, 0.24, 0.17
+    elseif lootData.isReputation then
+        r, g, b = 0.35, 0.85, 0.55
     elseif lootData.itemQuality then
         if ITEM_QUALITY_COLORS and ITEM_QUALITY_COLORS[lootData.itemQuality] then
             local qc = ITEM_QUALITY_COLORS[lootData.itemQuality]
@@ -381,7 +390,7 @@ local function PopulateToast(frame, lootData)
 
     -- Icon
     if showIcon then
-        frame.icon:SetTexture(lootData.itemIcon)
+        frame.icon:SetTexture(lootData.itemIcon or ns.ListenerUtils.QUESTION_MARK_ICON)
         frame.icon:Show()
     end
 
@@ -421,6 +430,29 @@ local function PopulateToast(frame, lootData)
 
         if lootData.victimName and lootData.victimName ~= "" then
             frame.itemType:SetText(lootData.victimName)
+            frame.itemType:SetTextColor(0.7, 0.7, 0.7)
+            frame.itemType:Show()
+        else
+            frame.itemType:Hide()
+        end
+
+        if db.display.showLooter then
+            frame.looter:SetText("You")
+            frame.looter:SetTextColor(0.3, 1.0, 0.3)
+            frame.looter:Show()
+        else
+            frame.looter:Hide()
+        end
+
+    elseif lootData.isReputation then
+        -- Reputation toast
+        frame.itemName:SetText(lootData.itemName)
+        frame.itemName:SetTextColor(0.35, 0.85, 0.55)
+        frame.quantity:Hide()
+        frame.itemLevel:Hide()
+
+        if lootData.factionName and lootData.factionName ~= "" then
+            frame.itemType:SetText(lootData.factionName)
             frame.itemType:SetTextColor(0.7, 0.7, 0.7)
             frame.itemType:Show()
         else

--- a/Display/ToastManager.lua
+++ b/Display/ToastManager.lua
@@ -206,6 +206,9 @@ local function FindDuplicate(lootData)
                 return toast, i
             elseif lootData.isHonor and toast.lootData.isHonor then
                 return toast, i
+            elseif lootData.isReputation and toast.lootData.isReputation
+                and toast.lootData.factionName == lootData.factionName then
+                return toast, i
             -- Gold/money stacking
             elseif lootData.copperAmount and toast.lootData.copperAmount then
                 return toast, i
@@ -217,6 +220,7 @@ local function FindDuplicate(lootData)
             -- Normal item stacking (skip currencies -- those stack by currencyID above)
             if not lootData.isXP and not toast.lootData.isXP
                 and not lootData.isHonor and not toast.lootData.isHonor
+                and not lootData.isReputation and not toast.lootData.isReputation
                 and not lootData.currencyID and not toast.lootData.currencyID
                 and toast.lootData.itemID == lootData.itemID
                 and toast.lootData.isSelf == lootData.isSelf then
@@ -242,6 +246,12 @@ local function FindDuplicate(lootData)
                     entry.itemName = "+" .. ns.ToastManager.FormatNumber(entry.honorAmount) .. " Honor"
                     entry.timestamp = now
                     return entry, nil -- nil index signals queued (not active)
+                elseif lootData.isReputation and entry.isReputation
+                    and entry.factionName == lootData.factionName then
+                    entry.reputationAmount = (entry.reputationAmount or 0) + (lootData.reputationAmount or 0)
+                    entry.itemName = "+" .. ns.ToastManager.FormatNumber(entry.reputationAmount) .. " Reputation"
+                    entry.timestamp = now
+                    return entry, nil -- nil index signals queued (not active)
                 elseif entry.copperAmount and lootData.copperAmount then
                     entry.copperAmount = entry.copperAmount + lootData.copperAmount
                     entry.timestamp = lootData.timestamp
@@ -255,6 +265,7 @@ local function FindDuplicate(lootData)
                 -- Normal item stacking (skip currencies)
                 if not lootData.isXP and not entry.isXP
                     and not lootData.isHonor and not entry.isHonor
+                    and not lootData.isReputation and not entry.isReputation
                     and not lootData.currencyID and not entry.currencyID
                     and entry.itemID == lootData.itemID
                     and entry.isSelf == lootData.isSelf then
@@ -299,6 +310,12 @@ local function ShowToast(lootData)
         elseif lootData.isHonor then
             existing.lootData.honorAmount = (existing.lootData.honorAmount or 0) + (lootData.honorAmount or 0)
             existing.lootData.itemName = "+" .. ns.ToastManager.FormatNumber(existing.lootData.honorAmount) .. " Honor"
+            existing.lootData.timestamp = GetTime()
+        elseif lootData.isReputation then
+            existing.lootData.reputationAmount = (existing.lootData.reputationAmount or 0)
+                + (lootData.reputationAmount or 0)
+            existing.lootData.itemName = "+" .. ns.ToastManager.FormatNumber(existing.lootData.reputationAmount)
+                .. " Reputation"
             existing.lootData.timestamp = GetTime()
         elseif existing.lootData.copperAmount and lootData.copperAmount then
             existing.lootData.copperAmount = existing.lootData.copperAmount + lootData.copperAmount
@@ -356,6 +373,7 @@ function ns.ToastManager.QueueToast(lootData)
     if ns.MessageBridge.IsSuppressed()
         and not lootData.isXP
         and not lootData.isHonor
+        and not lootData.isReputation
         and not lootData.isCurrency
         and not lootData.isRollWin then
         return
@@ -452,7 +470,10 @@ function ns.ToastManager.ShowTestToast()
           icon = 894556, id = 99999, isXP = true, xpAmount = 1234 },
         { name = "+150 Honor", quality = 1, level = 0, type = nil, subType = nil,
           icon = ns.HonorListener.GetHonorIcon(), id = 99997, isHonor = true, honorAmount = 150,
-          victimName = "Enemy Player" },
+           victimName = "Enemy Player" },
+        { name = "+250 Reputation", quality = 1, level = 0, type = nil, subType = nil,
+          icon = ns.ReputationListener.GetReputationIcon(), id = 99996, isReputation = true,
+          reputationAmount = 250, factionName = "The Sha'tar" },
     }
 
     local test = testItems[math.random(#testItems)]
@@ -482,6 +503,24 @@ function ns.ToastManager.ShowTestToast()
             victimName = test.victimName,
             itemIcon = test.icon,
             itemName = "+" .. ns.ToastManager.FormatNumber(amount) .. " Honor",
+            itemQuality = test.quality,
+            itemLevel = 0,
+            itemType = nil,
+            itemSubType = nil,
+            quantity = 1,
+            looter = UnitName("player") or "TestPlayer",
+            isSelf = true,
+            isCurrency = false,
+            timestamp = GetTime(),
+        }
+    elseif test.isReputation then
+        local amount = test.reputationAmount + math.random(0, 200)
+        lootData = {
+            isReputation = true,
+            reputationAmount = amount,
+            factionName = test.factionName,
+            itemIcon = test.icon,
+            itemName = "+" .. ns.ToastManager.FormatNumber(amount) .. " Reputation",
             itemQuality = test.quality,
             itemLevel = 0,
             itemType = nil,
@@ -657,6 +696,23 @@ function ns.ToastManager.RunStackTest(testType)
         }
     end
 
+    local function MakeReputationData()
+        return {
+            isReputation = true,
+            reputationAmount = 250,
+            factionName = "The Sha'tar",
+            itemIcon = ns.ReputationListener.GetReputationIcon(),
+            itemName = "+250 Reputation",
+            itemQuality = 1,
+            itemLevel = 0,
+            quantity = 1,
+            looter = UnitName("player") or "TestPlayer",
+            isSelf = true,
+            isCurrency = false,
+            timestamp = GetTime(),
+        }
+    end
+
     local function RunGroup(label, makeFunc)
         ns.Print("[Stack Test] Testing " .. ns.COLOR_WHITE .. label .. ns.COLOR_RESET .. " stacking...")
         FireToast(makeFunc(), 0)
@@ -672,14 +728,17 @@ function ns.ToastManager.RunStackTest(testType)
         RunGroup("gold", MakeGoldData)
     elseif testType == "honor" then
         RunGroup("honor", MakeHonorData)
+    elseif testType == "reputation" or testType == "rep" then
+        RunGroup("reputation", MakeReputationData)
     elseif testType == "all" then
         RunGroup("item", MakeItemData)
         addon:ScheduleTimer(function() RunGroup("XP", MakeXPData) end, 2.0)
         addon:ScheduleTimer(function() RunGroup("gold", MakeGoldData) end, 4.0)
         addon:ScheduleTimer(function() RunGroup("honor", MakeHonorData) end, 6.0)
+        addon:ScheduleTimer(function() RunGroup("reputation", MakeReputationData) end, 8.0)
     else
         ns.Print("Unknown test type: " .. ns.COLOR_WHITE .. (testType or "nil") .. ns.COLOR_RESET)
-        ns.Print("Usage: /dt test [stack|xp|gold|honor|all]")
+        ns.Print("Usage: /dt test [stack|xp|gold|honor|reputation|all]")
         return
     end
 end

--- a/DragonToast.toc
+++ b/DragonToast.toc
@@ -36,11 +36,13 @@ Display\ElvUISkin.lua
 Listeners\LootListener_TBC.lua
 Listeners\MailListener_TBC.lua
 Listeners\HonorListener_TBC.lua
+Listeners\ReputationListener_TBC.lua
 #@end-tbc-anniversary@
 #@non-tbc-anniversary@
 Listeners\LootListener_Retail.lua
 Listeners\MailListener_Retail.lua
 Listeners\HonorListener_Retail.lua
+Listeners\ReputationListener_Retail.lua
 Listeners\CurrencyListener_Retail.lua
 #@end-non-tbc-anniversary@
 

--- a/DragonToast_Options/Tabs/FiltersTab.lua
+++ b/DragonToast_Options/Tabs/FiltersTab.lua
@@ -167,7 +167,16 @@ local function CreateCurrencySection(parent, yOffset)
         set = function(value) db.profile.filters.showHonor = value end,
     })
     AnchorWidget(honor, parent, yOffset)
-    yOffset = yOffset - honor:GetHeight()
+    yOffset = yOffset - honor:GetHeight() - SPACING_BETWEEN_WIDGETS
+
+    local reputation = W.CreateToggle(parent, {
+        label = "Show Reputation",
+        tooltip = "Show toasts for reputation gains",
+        get = function() return db.profile.filters.showReputation end,
+        set = function(value) db.profile.filters.showReputation = value end,
+    })
+    AnchorWidget(reputation, parent, yOffset)
+    yOffset = yOffset - reputation:GetHeight()
 
     return yOffset
 end

--- a/Listeners/ReputationListener_Retail.lua
+++ b/Listeners/ReputationListener_Retail.lua
@@ -1,0 +1,138 @@
+-------------------------------------------------------------------------------
+-- ReputationListener_Retail.lua
+-- Reputation gain toast notifications
+--
+-- Supported versions: Retail, MoP Classic
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+local Utils = ns.ListenerUtils
+
+-------------------------------------------------------------------------------
+-- Version guard: only run on Retail or MoP Classic
+-------------------------------------------------------------------------------
+
+local WOW_PROJECT_ID = WOW_PROJECT_ID
+local WOW_PROJECT_MAINLINE = WOW_PROJECT_MAINLINE
+local WOW_PROJECT_MISTS_CLASSIC = WOW_PROJECT_MISTS_CLASSIC
+
+if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE and WOW_PROJECT_ID ~= WOW_PROJECT_MISTS_CLASSIC then return end
+
+-------------------------------------------------------------------------------
+-- Cached WoW API
+-------------------------------------------------------------------------------
+
+local GetTime = GetTime
+local UnitName = UnitName
+local tonumber = tonumber
+local string_match = string.match
+
+-------------------------------------------------------------------------------
+-- Constants
+-------------------------------------------------------------------------------
+
+local REPUTATION_ICON_FALLBACK = Utils.QUESTION_MARK_ICON
+local REPUTATION_QUALITY = 1
+local PATTERNS = {}
+
+local function AddPattern(globalName)
+    local pattern, captureOrder = Utils.BuildCapturePattern(_G[globalName], true)
+    if not pattern then return end
+
+    PATTERNS[#PATTERNS + 1] = {
+        pattern = pattern,
+        captureOrder = captureOrder,
+    }
+end
+
+-------------------------------------------------------------------------------
+-- Pattern Building
+-------------------------------------------------------------------------------
+
+local function InitPatterns()
+    PATTERNS = {}
+
+    AddPattern("FACTION_STANDING_INCREASED")
+    AddPattern("FACTION_STANDING_INCREASED_BONUS")
+    AddPattern("FACTION_STANDING_INCREASED_ACH_BONUS")
+end
+
+-------------------------------------------------------------------------------
+-- Reputation Parsing
+-------------------------------------------------------------------------------
+
+local function ParseReputationText(text)
+    if not text or text == "" then return nil, nil end
+
+    for _, entry in ipairs(PATTERNS) do
+        local captures = { string_match(text, entry.pattern) }
+        if #captures > 0 then
+            local capturedValues = {}
+            for index, placeholderIndex in ipairs(entry.captureOrder) do
+                capturedValues[placeholderIndex] = captures[index]
+            end
+
+            local factionName = capturedValues[1]
+            local amount = tonumber(capturedValues[2])
+            if factionName and amount then
+                return amount, factionName
+            end
+        end
+    end
+
+    return nil, nil
+end
+
+-------------------------------------------------------------------------------
+-- Event Handler
+-------------------------------------------------------------------------------
+
+local function OnChatMsgCombatFactionChange(_event, text)
+    local db = ns.Addon.db.profile
+    if not db.enabled then return end
+    if not db.filters.showReputation then return end
+
+    local reputationAmount, factionName = ParseReputationText(text)
+    if not reputationAmount or reputationAmount <= 0 then return end
+    if not factionName or factionName == "" then return end
+
+    local lootData = {
+        isReputation = true,
+        reputationAmount = reputationAmount,
+        factionName = factionName,
+        itemIcon = REPUTATION_ICON_FALLBACK,
+        itemName = "+" .. ns.FormatNumber(reputationAmount) .. " Reputation",
+        itemQuality = REPUTATION_QUALITY,
+        itemLevel = 0,
+        itemType = nil,
+        itemSubType = nil,
+        quantity = 1,
+        looter = UnitName("player") or "You",
+        isSelf = true,
+        isCurrency = false,
+        timestamp = GetTime(),
+    }
+
+    ns.ToastManager.QueueToast(lootData)
+end
+
+-------------------------------------------------------------------------------
+-- Public Interface
+-------------------------------------------------------------------------------
+
+ns.ReputationListener = ns.ReputationListener or {}
+
+function ns.ReputationListener.Initialize(addon)
+    InitPatterns()
+    addon:RegisterEvent("CHAT_MSG_COMBAT_FACTION_CHANGE", OnChatMsgCombatFactionChange)
+    ns.DebugPrint("ReputationListener initialized")
+end
+
+function ns.ReputationListener.Shutdown()
+    ns.Addon:UnregisterEvent("CHAT_MSG_COMBAT_FACTION_CHANGE")
+    ns.DebugPrint("ReputationListener shutdown")
+end
+
+function ns.ReputationListener.GetReputationIcon()
+    return REPUTATION_ICON_FALLBACK
+end

--- a/Listeners/ReputationListener_TBC.lua
+++ b/Listeners/ReputationListener_TBC.lua
@@ -1,0 +1,137 @@
+-------------------------------------------------------------------------------
+-- ReputationListener_TBC.lua
+-- Reputation gain toast notifications
+--
+-- Supported versions: TBC Anniversary
+-------------------------------------------------------------------------------
+
+local ADDON_NAME, ns = ...
+local Utils = ns.ListenerUtils
+
+-------------------------------------------------------------------------------
+-- Version guard: only run on TBC Anniversary
+-------------------------------------------------------------------------------
+
+local WOW_PROJECT_ID = WOW_PROJECT_ID
+local WOW_PROJECT_BURNING_CRUSADE_CLASSIC = WOW_PROJECT_BURNING_CRUSADE_CLASSIC
+
+if WOW_PROJECT_ID ~= WOW_PROJECT_BURNING_CRUSADE_CLASSIC then return end
+
+-------------------------------------------------------------------------------
+-- Cached WoW API
+-------------------------------------------------------------------------------
+
+local GetTime = GetTime
+local UnitName = UnitName
+local tonumber = tonumber
+local string_match = string.match
+
+-------------------------------------------------------------------------------
+-- Constants
+-------------------------------------------------------------------------------
+
+local REPUTATION_ICON_FALLBACK = Utils.QUESTION_MARK_ICON
+local REPUTATION_QUALITY = 1
+local PATTERNS = {}
+
+local function AddPattern(globalName)
+    local pattern, captureOrder = Utils.BuildCapturePattern(_G[globalName], true)
+    if not pattern then return end
+
+    PATTERNS[#PATTERNS + 1] = {
+        pattern = pattern,
+        captureOrder = captureOrder,
+    }
+end
+
+-------------------------------------------------------------------------------
+-- Pattern Building
+-------------------------------------------------------------------------------
+
+local function InitPatterns()
+    PATTERNS = {}
+
+    AddPattern("FACTION_STANDING_INCREASED")
+    AddPattern("FACTION_STANDING_INCREASED_BONUS")
+    AddPattern("FACTION_STANDING_INCREASED_ACH_BONUS")
+end
+
+-------------------------------------------------------------------------------
+-- Reputation Parsing
+-------------------------------------------------------------------------------
+
+local function ParseReputationText(text)
+    if not text or text == "" then return nil, nil end
+
+    for _, entry in ipairs(PATTERNS) do
+        local captures = { string_match(text, entry.pattern) }
+        if #captures > 0 then
+            local capturedValues = {}
+            for index, placeholderIndex in ipairs(entry.captureOrder) do
+                capturedValues[placeholderIndex] = captures[index]
+            end
+
+            local factionName = capturedValues[1]
+            local amount = tonumber(capturedValues[2])
+            if factionName and amount then
+                return amount, factionName
+            end
+        end
+    end
+
+    return nil, nil
+end
+
+-------------------------------------------------------------------------------
+-- Event Handler
+-------------------------------------------------------------------------------
+
+local function OnChatMsgCombatFactionChange(_event, text)
+    local db = ns.Addon.db.profile
+    if not db.enabled then return end
+    if not db.filters.showReputation then return end
+
+    local reputationAmount, factionName = ParseReputationText(text)
+    if not reputationAmount or reputationAmount <= 0 then return end
+    if not factionName or factionName == "" then return end
+
+    local lootData = {
+        isReputation = true,
+        reputationAmount = reputationAmount,
+        factionName = factionName,
+        itemIcon = REPUTATION_ICON_FALLBACK,
+        itemName = "+" .. ns.FormatNumber(reputationAmount) .. " Reputation",
+        itemQuality = REPUTATION_QUALITY,
+        itemLevel = 0,
+        itemType = nil,
+        itemSubType = nil,
+        quantity = 1,
+        looter = UnitName("player") or "You",
+        isSelf = true,
+        isCurrency = false,
+        timestamp = GetTime(),
+    }
+
+    ns.ToastManager.QueueToast(lootData)
+end
+
+-------------------------------------------------------------------------------
+-- Public Interface
+-------------------------------------------------------------------------------
+
+ns.ReputationListener = ns.ReputationListener or {}
+
+function ns.ReputationListener.Initialize(addon)
+    InitPatterns()
+    addon:RegisterEvent("CHAT_MSG_COMBAT_FACTION_CHANGE", OnChatMsgCombatFactionChange)
+    ns.DebugPrint("ReputationListener initialized")
+end
+
+function ns.ReputationListener.Shutdown()
+    ns.Addon:UnregisterEvent("CHAT_MSG_COMBAT_FACTION_CHANGE")
+    ns.DebugPrint("ReputationListener shutdown")
+end
+
+function ns.ReputationListener.GetReputationIcon()
+    return REPUTATION_ICON_FALLBACK
+end

--- a/spec/ListenerUtils_spec.lua
+++ b/spec/ListenerUtils_spec.lua
@@ -1,0 +1,65 @@
+-------------------------------------------------------------------------------
+-- ListenerUtils_spec.lua
+-- Unit tests for capture-order parsing helpers
+-------------------------------------------------------------------------------
+
+local function LoadListenerUtils()
+    -- luacheck: push ignore 121
+    GOLD_AMOUNT = "%dg"
+    SILVER_AMOUNT = "%ds"
+    COPPER_AMOUNT = "%dc"
+    GOLD_AMOUNT_TEXTURE = "%d|Tgold|t"
+    SILVER_AMOUNT_TEXTURE = "%d|Tsilver|t"
+    COPPER_AMOUNT_TEXTURE = "%d|Tcopper|t"
+    -- luacheck: pop
+
+    local ns = {
+        ListenerUtils = {},
+    }
+
+    local chunk, err = loadfile("Core/ListenerUtils.lua")
+    if not chunk then
+        error("Failed to load Core/ListenerUtils.lua: " .. (err or "unknown error"))
+    end
+
+    chunk("DragonToast", ns)
+    return ns.ListenerUtils
+end
+
+local function RemapCaptures(captures, captureOrder)
+    local capturedValues = {}
+
+    for index, placeholderIndex in ipairs(captureOrder) do
+        capturedValues[placeholderIndex] = captures[index]
+    end
+
+    return capturedValues
+end
+
+describe("ListenerUtils.BuildCapturePattern", function()
+    local Utils
+
+    setup(function()
+        Utils = LoadListenerUtils()
+    end)
+
+    it("uses 1-based indexes for non-positional placeholders", function()
+        local pattern, captureOrder = Utils.BuildCapturePattern("Reputation with %s increased by %d.", true)
+        local captures = { string.match("Reputation with The Sha'tar increased by 250.", pattern) }
+        local capturedValues = RemapCaptures(captures, captureOrder)
+
+        assert.same({ 1, 2 }, captureOrder)
+        assert.equal("The Sha'tar", capturedValues[1])
+        assert.equal("250", capturedValues[2])
+    end)
+
+    it("preserves positional placeholder order for localized strings", function()
+        local pattern, captureOrder = Utils.BuildCapturePattern("%2$d reputation with %1$s.", true)
+        local captures = { string.match("250 reputation with The Sha'tar.", pattern) }
+        local capturedValues = RemapCaptures(captures, captureOrder)
+
+        assert.same({ 2, 1 }, captureOrder)
+        assert.equal("The Sha'tar", capturedValues[1])
+        assert.equal("250", capturedValues[2])
+    end)
+end)

--- a/spec/SlashCommands_spec.lua
+++ b/spec/SlashCommands_spec.lua
@@ -1,0 +1,74 @@
+-------------------------------------------------------------------------------
+-- SlashCommands_spec.lua
+-- Unit tests for slash command normalization
+-------------------------------------------------------------------------------
+
+local function LoadSlashCommands(namespace)
+    local chunk, err = loadfile("Core/SlashCommands.lua")
+    if not chunk then
+        error("Failed to load Core/SlashCommands.lua: " .. (err or "unknown error"))
+    end
+
+    chunk("DragonToast", namespace)
+end
+
+describe("HandleSlashCommand", function()
+    local ns
+    local clearCalled
+    local printedMessage
+    local originalPrint
+
+    before_each(function()
+        originalPrint = _G.print
+        _G.print = function() end
+
+        clearCalled = false
+        printedMessage = nil
+
+        ns = {
+            COLOR_GOLD = "",
+            COLOR_GREEN = "",
+            COLOR_RED = "",
+            COLOR_WHITE = "",
+            COLOR_RESET = "",
+            Addon = {
+                db = {
+                    profile = {
+                        enabled = true,
+                        filters = {},
+                        display = {},
+                        animation = {},
+                        sound = {},
+                        combat = {},
+                        elvui = {},
+                        minimap = {},
+                    },
+                },
+            },
+            ToastManager = {
+                ClearAll = function()
+                    clearCalled = true
+                end,
+                IsTestModeActive = function()
+                    return false
+                end,
+            },
+            Print = function(message)
+                printedMessage = message
+            end,
+        }
+
+        LoadSlashCommands(ns)
+    end)
+
+    after_each(function()
+        _G.print = originalPrint
+    end)
+
+    it("trims and lowercases commands with surrounding whitespace", function()
+        ns.HandleSlashCommand("   CLEAR   ")
+
+        assert.is_true(clearCalled)
+        assert.equal("All toasts cleared.", printedMessage)
+    end)
+end)

--- a/spec/wow_mock.lua
+++ b/spec/wow_mock.lua
@@ -212,6 +212,10 @@ function M.CreateNamespace()
         GetHonorIcon = function() return 463450 end,
     }
 
+    ns.ReputationListener = {
+        GetReputationIcon = function() return 134400 end,
+    }
+
     -- Mock Addon (Ace3 mixin)
     ns.Addon = {
         db = {
@@ -236,6 +240,9 @@ function M.CreateNamespace()
                     showGold = true,
                     showQuestItems = true,
                     showXP = true,
+                    showHonor = true,
+                    showMail = true,
+                    showReputation = true,
                 },
                 combat = {
                     deferInCombat = false,


### PR DESCRIPTION
## Summary
- add cross-version reputation gain toasts as a first-class non-item toast type
- add `showReputation` config and Filters UI toggle
- wire new reputation listeners into addon init and TOC load order
- add reputation rendering, stacking, and suppression bypass behavior
- add regression tests for listener capture order and slash command normalization

## Testing
- `luacheck . --no-color`
- `pwsh -File "Scripts/_run_tests.ps1"`

## Manual verification
- enabled `/console scriptErrors 1`
- verified the new Filters toggle for reputation
- verified reputation toasts show faction name and gain amount
- verified same-faction gains stack and different factions do not
- verified reputation bypasses suppression like XP and honor
- verified filter state persists across reload

Closes #93
