### PR TITLE
fix: clarify slash command help and toggle behavior

### DIFF
--- a/Core/SlashCommands.lua
+++ b/Core/SlashCommands.lua
@@ -66,7 +66,8 @@ end
 
 local function PrintHelp()
     print(ns.COLOR_GOLD .. "--- DragonToast Commands ---" .. ns.COLOR_RESET)
-    print("  " .. ns.COLOR_WHITE .. "/dt" .. ns.COLOR_RESET .. " — Toggle addon on/off")
+    print("  " .. ns.COLOR_WHITE .. "/dt" .. ns.COLOR_RESET .. " — Show this help")
+    print("  " .. ns.COLOR_WHITE .. "/dt toggle" .. ns.COLOR_RESET .. " — Toggle addon on/off")
     print("  " .. ns.COLOR_WHITE .. "/dt config" .. ns.COLOR_RESET .. " — Open settings panel")
     print("  " .. ns.COLOR_WHITE .. "/dt lock" .. ns.COLOR_RESET .. " — Toggle anchor lock (drag to move)")
     print("  " .. ns.COLOR_WHITE .. "/dt test" .. ns.COLOR_RESET .. " — Show a test toast")
@@ -92,20 +93,28 @@ local function NormalizeCommand(input)
     return string_lower(trimmedInput)
 end
 
+local function ToggleAddon()
+    local db = ns.Addon.db.profile
+    db.enabled = not db.enabled
+
+    if db.enabled then
+        ns.Addon:OnEnable()
+        ns.Print("Addon " .. ns.COLOR_GREEN .. "enabled" .. ns.COLOR_RESET)
+        return
+    end
+
+    ns.Addon:OnDisable()
+    ns.Print("Addon " .. ns.COLOR_RED .. "disabled" .. ns.COLOR_RESET)
+end
+
 function ns.HandleSlashCommand(input)
     local cmd = NormalizeCommand(input)
 
     if cmd == "" then
-        -- Toggle addon
-        local db = ns.Addon.db.profile
-        db.enabled = not db.enabled
-        if db.enabled then
-            ns.Addon:OnEnable()
-            ns.Print("Addon " .. ns.COLOR_GREEN .. "enabled" .. ns.COLOR_RESET)
-        else
-            ns.Addon:OnDisable()
-            ns.Print("Addon " .. ns.COLOR_RED .. "disabled" .. ns.COLOR_RESET)
-        end
+        PrintHelp()
+
+    elseif cmd == "toggle" then
+        ToggleAddon()
 
     elseif cmd == "config" or cmd == "options" or cmd == "settings" then
         -- Open options panel

--- a/README.md
+++ b/README.md
@@ -57,19 +57,28 @@
 
 ## ⌨️ Commands
 
-All commands use the `/dt` prefix (or the full `/dragontoast`):
+Use `/dt` or `/dragontoast`.
 
-| Command         | Description                             |
-|:----------------|:----------------------------------------|
-| `/dt`           | Toggle addon on/off                     |
-| `/dt config`    | Open settings panel                     |
-| `/dt lock`      | Toggle anchor lock (drag to reposition) |
-| `/dt test`      | Show a test toast                       |
-| `/dt testmode`  | Toggle continuous test toasts           |
-| `/dt clear`     | Dismiss all active toasts               |
-| `/dt reset`     | Reset anchor position to default        |
-| `/dt status`    | Show current settings                   |
-| `/dt help`      | Show available commands                 |
+Typing `/dt` by itself shows the help list. Use `/dt toggle` if you want to enable or disable the addon.
+
+| Command | What it does |
+|:--------|:-------------|
+| `/dt` | Show the help list |
+| `/dt help` | Show the help list |
+| `/dt toggle` | Turn DragonToast on or off |
+| `/dt config` | Open the settings panel |
+| `/dt lock` | Lock or unlock the toast anchor so you can move it |
+| `/dt test` | Show a single test toast |
+| `/dt test stack` | Test item stacking with rapid item toasts |
+| `/dt test xp` | Test XP stacking |
+| `/dt test gold` | Test gold stacking |
+| `/dt test honor` | Test honor stacking |
+| `/dt test reputation` | Test reputation stacking |
+| `/dt test all` | Run all stacking tests |
+| `/dt testmode` | Toggle continuous test toasts |
+| `/dt clear` | Dismiss all active toasts |
+| `/dt reset` | Reset the toast anchor to its default position |
+| `/dt status` | Show your current DragonToast settings |
 
 ## ⚙️ Configuration
 


### PR DESCRIPTION
## Summary
- Makes DragonToast slash commands easier to discover and less surprising by showing help when /dt is used without arguments.

## Changes
- Updates /dt to show the help list instead of toggling the addon.
- Adds /dt toggle as the explicit command for enabling or disabling DragonToast.
- Refreshes the README command section to match the current slash command behavior and available test commands.

## Testing
- GitHub Actions: luacheck
- GitHub Actions: test
