### PR TITLE
feat: stack toasts for their full visible lifetime, not a fixed window (#163)

### DIFF
--- a/DragonToast/Display/ToastManager.lua
+++ b/DragonToast/Display/ToastManager.lua
@@ -327,11 +327,10 @@ end
 local function FindDuplicate(lootData)
     if lootData.isCurrency and not lootData.copperAmount and not lootData.currencyID then return nil end
 
-    local now = GetTime()
-
-    -- Search active toasts first
+    -- Active toasts stack for their full visible lifetime (until _isExiting).
+    -- No time window is applied here - if the toast is still on screen, it accepts stacks.
     for i, toast in ipairs(activeToasts) do
-        if not toast._isExiting and toast.lootData and IsRecentLoot(toast.lootData.timestamp, now) then
+        if not toast._isExiting and toast.lootData then
             local duplicateKind = GetDuplicateKind(toast.lootData, lootData)
             if duplicateKind then
                 return toast, i, duplicateKind
@@ -339,7 +338,11 @@ local function FindDuplicate(lootData)
         end
     end
 
-    -- Search pending queues (toastQueue, then combatQueue)
+    -- Queued entries are time-gated: entries older than DUPLICATE_WINDOW do not receive
+    -- stacks and a new entry is queued instead. This intentionally differs from the active
+    -- path - queued items have no visible frame to signal liveness, so the time window
+    -- acts as a staleness guard.
+    local now = GetTime()
     local queues = { toastQueue, combatQueue }
     for _, queue in ipairs(queues) do
         for idx = queue.first, queue.last do

--- a/spec/ToastManager_spec.lua
+++ b/spec/ToastManager_spec.lua
@@ -242,9 +242,9 @@ describe("ToastManager", function()
             assert.equal(1, idx)
         end)
 
-        it("returns nil when timestamp exceeds DUPLICATE_WINDOW", function()
+        it("returns nil when active toast is exiting", function()
             T.ShowToast(makeXPData())
-            mock.AdvanceTime(T.DUPLICATE_WINDOW + 0.1)
+            T.activeToasts[1]._isExiting = true
             assert.is_nil(T.FindDuplicate(makeXPData()))
         end)
 
@@ -371,6 +371,29 @@ describe("ToastManager", function()
             assert.is_nil(idx)
 
             ns.Addon.db.profile.display.maxToasts = 5
+        end)
+
+        it("does not merge into a stale queued entry (older than DUPLICATE_WINDOW)", function()
+            -- Fill active toasts so the first event is queued
+            for i = 1, ns.Addon.db.profile.display.maxToasts do
+                T.ShowToast(makeItemData({ itemID = 1000 + i }))
+            end
+
+            -- Queue an XP entry
+            T.ShowToast(makeXPData({ xpAmount = 200, timestamp = GetTime() }))
+            local sizeBefore = T.QueueSize(T.toastQueue)
+
+            -- Advance time past DUPLICATE_WINDOW
+            mock.SetTime(GetTime() + T.DUPLICATE_WINDOW + 0.1)
+
+            -- Queue another XP entry - should NOT merge with the stale queued entry
+            T.ShowToast(makeXPData({ xpAmount = 300, timestamp = GetTime() }))
+            local sizeAfter = T.QueueSize(T.toastQueue)
+
+            assert.equal(sizeBefore + 1, sizeAfter) -- two separate entries in queue
+            -- The stale entry must not have been mutated
+            local staleEntry = T.toastQueue[T.toastQueue.first]
+            assert.equal(200, staleEntry.xpAmount)
         end)
 
     end)
@@ -578,11 +601,11 @@ describe("ToastManager", function()
             assert.equal(60000, T.activeToasts[1].lootData.copperAmount)
         end)
 
-        it("event after DUPLICATE_WINDOW creates separate toast", function()
+        it("event onto exiting toast creates separate toast", function()
             TM.QueueToast(makeXPData({ xpAmount = 100 }))
             assert.equal(1, #T.activeToasts)
 
-            mock.AdvanceTime(T.DUPLICATE_WINDOW + 0.1)
+            T.activeToasts[1]._isExiting = true
             TM.QueueToast(makeXPData({ xpAmount = 200 }))
             assert.equal(2, #T.activeToasts)
         end)

--- a/spec/wow_mock.lua
+++ b/spec/wow_mock.lua
@@ -15,10 +15,6 @@ function M.SetTime(t)
     mockTime = t
 end
 
-function M.AdvanceTime(dt)
-    mockTime = mockTime + dt
-end
-
 -- luacheck: push ignore 121 122
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Remove the hardcoded 2-second duplicate window from the active-toast path in `FindDuplicate`. Active toasts now accept duplicate stacks for as long as they remain visible, and the queue path keeps `IsRecentLoot` as the staleness guard.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Closes #163

## Testing

- [ ] Luacheck passes (`luacheck .`)
- [ ] Tested in-game manually
- [ ] WoW version(s) tested on: not tested locally

## Checklist

- [x] My code follows the project's code style (4-space indent, 120 char lines)
- [ ] I have tested my changes in-game
- [x] Luacheck reports no warnings
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/) format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced duplicate loot notification handling: active on-screen toasts now stack duplicates throughout their full visible duration without time restrictions, while queued notifications maintain existing time-window-based deduplication.

* **Tests**
  * Expanded test coverage for queue deduplication scenarios and updated duplicate-detection test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->