### PR TITLE
feat: event-driven item loading and queue stagger (#167)

### DIFF
--- a/DragonToast/Core/Config.lua
+++ b/DragonToast/Core/Config.lua
@@ -31,6 +31,7 @@ local defaults = {
 
         display = {
             maxToasts = 7,
+            queueStagger = 0.1,
             toastWidth = 350,
             toastHeight = 48,
             growDirection = "UP",
@@ -124,6 +125,7 @@ local SIMPLE_MIGRATIONS = {
     { version = 6, section = "filters", key = "showReputation", default = true },
     { version = 7, section = "animation", key = "pauseOnHover",  default = true },
     { version = 8, section = "display",   key = "showItemCount", default = false },
+    { version = 9, section = "display",   key = "queueStagger", default = 0.1 },
 }
 
 local function MigrateProfile(db)

--- a/DragonToast/Core/ListenerUtils.lua
+++ b/DragonToast/Core/ListenerUtils.lua
@@ -14,6 +14,16 @@ local tonumber = tonumber
 local math_floor = math.floor
 local string_format = string.format
 local table_concat = table.concat
+local table_insert = table.insert
+local ipairs = ipairs
+local next = next
+
+-- Pending item lookups: itemID (number) -> { buildFunc, filterFunc }
+-- Multiple entries can share the same itemID (e.g. two loots of the same item in quick succession)
+-- Use an array of entries per itemID to handle that correctly.
+local pendingItems = {}
+local itemEventRegistered = false
+local registeredAddon = nil
 
 local COPPER_PER_SILVER = 100
 local COPPER_PER_GOLD = 10000
@@ -169,5 +179,62 @@ function Utils.RetryWithTimer(addon, buildFunc, filterFunc, retries)
         addon:ScheduleTimer(function()
             Utils.RetryWithTimer(addon, buildFunc, filterFunc, retries + 1)
         end, Utils.RETRY_INTERVAL)
+    end
+end
+
+-------------------------------------------------------------------------------
+-- WaitForItem(addon, itemLink, buildFunc, filterFunc)
+-- Waits for GetItemInfo to be available for itemLink, then builds and queues
+-- a toast. Uses GET_ITEM_INFO_RECEIVED instead of polling to avoid up-to-1s
+-- lag on uncached items.
+-------------------------------------------------------------------------------
+
+function Utils.WaitForItem(addon, itemLink, buildFunc, filterFunc)
+    local data = buildFunc()
+    if data then
+        if filterFunc(data) then
+            ns.ToastManager.QueueToast(data)
+        end
+        return
+    end
+
+    -- Item not cached yet - extract itemID and register for the event
+    local itemID = tonumber(itemLink:match("item:(%d+)"))
+    if not itemID then return end
+
+    if not pendingItems[itemID] then
+        pendingItems[itemID] = {}
+    end
+    table_insert(pendingItems[itemID], { buildFunc = buildFunc, filterFunc = filterFunc })
+
+    if not itemEventRegistered then
+        itemEventRegistered = true
+        registeredAddon = addon
+        addon:RegisterEvent("GET_ITEM_INFO_RECEIVED", function(_, id, success)
+            local entries = pendingItems[id]
+            if not entries then return end
+
+            pendingItems[id] = nil
+
+            if success ~= true then
+                -- Item data unavailable - silently drop
+                ns.DebugPrint("WaitForItem: item " .. tostring(id) .. " data unavailable (success=" ..
+                    tostring(success) .. ")")
+            else
+                for _, entry in ipairs(entries) do
+                    local builtData = entry.buildFunc()
+                    if builtData and entry.filterFunc(builtData) then
+                        ns.ToastManager.QueueToast(builtData)
+                    end
+                end
+            end
+
+            -- Unregister when no more pending items
+            if not next(pendingItems) then
+                itemEventRegistered = false
+                registeredAddon:UnregisterEvent("GET_ITEM_INFO_RECEIVED")
+                registeredAddon = nil
+            end
+        end)
     end
 end

--- a/DragonToast/Display/ToastManager.lua
+++ b/DragonToast/Display/ToastManager.lua
@@ -30,6 +30,7 @@ local toastQueue = QueueUtils.New()            -- overflow queue (FIFO, O(1) pus
 local combatQueue = QueueUtils.New()           -- deferred-during-combat queue (FIFO, O(1) push/pop)
 local anchorFrame = nil    -- invisible anchor frame for positioning
 local isInitialized = false
+local flushStaggerTimer = nil  -- pending AceTimer handle for staggered queue flush
 
 -------------------------------------------------------------------------------
 -- Constants
@@ -450,12 +451,27 @@ function ns.ToastManager.QueueToast(lootData)
     ShowToast(lootData)
 end
 
-function ns.ToastManager.FlushQueue()
-    -- Process overflow queue
-    while QueueUtils.Size(toastQueue) > 0 and #activeToasts < ns.Addon.db.profile.display.maxToasts do
+local function FlushNext()
+    flushStaggerTimer = nil
+    local db = ns.Addon.db.profile
+    local stagger = db.display.queueStagger or 0
+    while QueueUtils.Size(toastQueue) > 0 and #activeToasts < db.display.maxToasts do
         local lootData = QueueUtils.Pop(toastQueue)
         ShowToast(lootData)
+        if stagger > 0 then
+            flushStaggerTimer = ns.Addon:ScheduleTimer(FlushNext, stagger)
+            return
+        end
     end
+end
+
+function ns.ToastManager.FlushQueue()
+    -- Cancel any pending stagger timer before starting a new flush pass
+    if flushStaggerTimer then
+        ns.Addon:CancelTimer(flushStaggerTimer)
+        flushStaggerTimer = nil
+    end
+    FlushNext()
 end
 
 local function FlushCombatQueue()
@@ -494,6 +510,10 @@ function ns.ToastManager.OnToastFinished(toast)
 end
 
 function ns.ToastManager.ClearAll()
+    if flushStaggerTimer then
+        ns.Addon:CancelTimer(flushStaggerTimer)
+        flushStaggerTimer = nil
+    end
     ns.TestToasts.StopTestMode()
     -- Cancel all animations and hide all toasts
     for _, toast in ipairs(activeToasts) do

--- a/DragonToast/Listeners/LootListener_Shared.lua
+++ b/DragonToast/Listeners/LootListener_Shared.lua
@@ -345,8 +345,9 @@ function ns.LootListenerShared.Create(config)
         local itemLink, quantity, looter, isSelf = ParseLootMessage(msg, lootCategories, playerName)
         if not itemLink then return end
 
-        Utils.RetryWithTimer(
+        Utils.WaitForItem(
             owner,
+            itemLink,
             function() return BuildLootData(itemLink, quantity, looter or UNKNOWN, isSelf) end,
             PassesFilter
         )


### PR DESCRIPTION
## Summary

Fixes direct loot toast lag and smooths burst flush behavior.

### Changes

**Event-driven item loading** (`Core/ListenerUtils.lua`, `Listeners/LootListener_Shared.lua`)
- Added `Utils.WaitForItem` - replaces the polling retry loop (`RetryWithTimer`) in the direct loot path with a `GET_ITEM_INFO_RECEIVED` event listener
- Toast fires as soon as WoW delivers item data instead of waiting for the next 0.2s poll tick (up to 1s lag eliminated)
- Handles rapid duplicate loots of the same item (per-itemID entry array)
- Works on all supported WoW versions (Retail, TBC Anniversary, MoP Classic)
- `RetryWithTimer` kept for `MailListener_Shared.lua` which still uses it

**Configurable queue stagger** (`Core/Config.lua`, `Display/ToastManager.lua`)
- Added `display.queueStagger = 0.1` config default (schema version 9)
- `FlushQueue` now staggers overflow toast pops by `queueStagger` seconds via AceTimer instead of dumping all at once
- Setting `queueStagger = 0` restores the old immediate-dump behavior
- Schema migration ensures existing profiles get the default on upgrade

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing
- `luacheck .` - 0 new warnings (29 pre-existing Libs/ warnings unchanged)
- `busted --verbose` - 57/57 tests pass

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new luacheck warnings
- [x] All existing tests pass

Closes #167