### PR TITLE
fix: correct DragonWidgets external path in .pkgmeta

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -12,7 +12,7 @@ externals:
   DragonToast/Libs/LibDBIcon-1.0: https://repos.wowace.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
   DragonToast/Libs/LibSharedMedia-3.0: https://repos.wowace.com/wow/libsharedmedia-3-0/trunk/LibSharedMedia-3.0
   DragonToast/Libs/LibAnimate: https://github.com/Xerrion/LibAnimate
-  DragonToast/DragonToast_Options/Libs/DragonWidgets: https://github.com/Xerrion/DragonWidgets
+  DragonToast_Options/Libs/DragonWidgets: https://github.com/Xerrion/DragonWidgets
 
 ignore:
   - ".git*"


### PR DESCRIPTION
\ had an incorrect prefix that prevented the BigWigsMods packager from placing it in the right location.

**Before:**
\
\
\
\
\
\
\
\
\
\
`yaml
DragonToast/DragonToast_Options/Libs/DragonWidgets: https://github.com/Xerrion/DragonWidgets
`

**After:**
`yaml
DragonToast_Options/Libs/DragonWidgets: https://github.com/Xerrion/DragonWidgets
`

The move-folders directive maps DragonToast/DragonToast_Options -> DragonToast_Options. The external path key must match the **pre-move** structure relative to the repo root. Using the DragonToast/ prefix caused the packager to place DragonWidgets inside a stray nested folder instead of DragonToast_Options/Libs/DragonWidgets/, making DragonWidgetsNS undefined at runtime and breaking the options UI.

This is the same bug as DragonLoot#136.

## Type of Change
- [x] Bug fix

## Testing
- Packaging: trigger packager.yml and verify DragonWidgets lands in DragonToast_Options/Libs/DragonWidgets/DragonWidgets/ in the built zip.

## Checklist
- [x] .pkgmeta external path corrected
- [x] No other files changed