### PR TITLE
fix: guard OnToastFinished in OnLeave against active lifecycle phases (#171)

### DIFF
--- a/DragonToast/Display/ToastFrame.lua
+++ b/DragonToast/Display/ToastFrame.lua
@@ -555,9 +555,11 @@ local function SetupToastScripts(frame)
             end
         end
 
-        if not resumed then
+        if not resumed and self._phase == nil and not self._isExiting then
             ns.ToastManager.OnToastFinished(self)
         end
+        -- If _phase is set, the LibAnimate lifecycle is still running naturally
+        -- (e.g. attention phase was never paused); it will call OnToastFinished itself.
     end)
 end
 


### PR DESCRIPTION
## What
Toasts were vanishing instantly when the cursor hovered during the **attention animation phase** (the quality-gated bounce/pulse before the hold timer).

## Root Cause
In `OnLeave`, the fallback `OnToastFinished(self)` fired whenever `resumed == false`. During the attention phase, `_isHovered` is set to `true` on enter but nothing is actually paused - LibAnimate keeps running. On leave, `ResumeFromHoverHold` returns `false` (the `_hoverHoldCallback` is only set during the hold phase), so `resumed` stayed `false` and the toast was force-finished immediately.

## Fix
Added `and self._phase == nil and not self._isExiting` to the fallback guard. `OnToastFinished` is now only called from `OnLeave` as a last resort when the lifecycle has genuinely stalled (no active phase, not currently exiting). If `_phase` is set, the LibAnimate queue is still running and will call `OnToastFinished` naturally via its own `onFinished` callback.

## Changes
- `DragonToast/Display/ToastFrame.lua`: Two-predicate guard added to `OnLeave` fallback

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

Closes #171